### PR TITLE
[Feature/#28] 핀 선택시 가게 조회 및 상세 조회

### DIFF
--- a/server-api/src/main/java/com/depromeet/domains/bookmark/controller/BookmarkController.java
+++ b/server-api/src/main/java/com/depromeet/domains/bookmark/controller/BookmarkController.java
@@ -1,0 +1,30 @@
+package com.depromeet.domains.bookmark.controller;
+
+import com.depromeet.annotation.AuthUser;
+import com.depromeet.common.exception.CustomResponseEntity;
+import com.depromeet.domains.bookmark.dto.response.BookmarkingResponse;
+import com.depromeet.domains.bookmark.service.BookmarkService;
+import com.depromeet.domains.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class BookmarkController {
+
+    private final BookmarkService bookmarkService;
+
+    @PostMapping("/bookmarks/{storeId}")
+    public CustomResponseEntity<BookmarkingResponse> createBookmark(@PathVariable Long storeId, @AuthUser User user) {
+        return CustomResponseEntity.success(bookmarkService.createBookmark(storeId, user));
+    }
+
+    @DeleteMapping("/bookmarks/{bookmarkId}")
+    public CustomResponseEntity<BookmarkingResponse> deleteBookmark(@PathVariable Long bookmarkId, @AuthUser User user) {
+        return CustomResponseEntity.success(bookmarkService.deleteBookmark(bookmarkId, user));
+    }
+}

--- a/server-api/src/main/java/com/depromeet/domains/bookmark/dto/response/BookmarkingResponse.java
+++ b/server-api/src/main/java/com/depromeet/domains/bookmark/dto/response/BookmarkingResponse.java
@@ -1,0 +1,19 @@
+package com.depromeet.domains.bookmark.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BookmarkingResponse {
+
+    private Long bookmarkId;
+    private Long userId;
+
+    public static BookmarkingResponse of(Long bookmarkId, Long userId) {
+        return BookmarkingResponse.builder()
+                .bookmarkId(bookmarkId)
+                .userId(userId)
+                .build();
+    }
+}

--- a/server-api/src/main/java/com/depromeet/domains/bookmark/service/BookmarkService.java
+++ b/server-api/src/main/java/com/depromeet/domains/bookmark/service/BookmarkService.java
@@ -1,0 +1,46 @@
+package com.depromeet.domains.bookmark.service;
+
+import com.depromeet.common.exception.CustomException;
+import com.depromeet.common.exception.Result;
+import com.depromeet.domains.bookmark.dto.response.BookmarkingResponse;
+import com.depromeet.domains.bookmark.entity.Bookmark;
+import com.depromeet.domains.bookmark.repository.BookmarkRepository;
+import com.depromeet.domains.store.entity.Store;
+import com.depromeet.domains.store.repository.StoreRepository;
+import com.depromeet.domains.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BookmarkService {
+
+    private final BookmarkRepository bookmarkRepository;
+    private final StoreRepository storeRepository;
+
+
+    public BookmarkingResponse createBookmark(Long storeId, User user) {
+
+        Store store = storeRepository.findById(storeId).orElseThrow(() -> new CustomException(Result.NOT_FOUND_STORE));
+
+        Bookmark bookmark = Bookmark.builder()
+                .store(store)
+                .user(user)
+                .build();
+
+        Bookmark savedBookmark = bookmarkRepository.save(bookmark);
+
+        return BookmarkingResponse.of(savedBookmark.getBookmarkId(), user.getUserId());
+    }
+
+    public BookmarkingResponse deleteBookmark(Long bookmarkId, User user) {
+        Bookmark bookmark = bookmarkRepository.findById(bookmarkId).orElseThrow(() -> new CustomException(Result.NOT_FOUND_BOOKMARK));
+
+        if (!bookmark.getUser().getUserId().equals(user.getUserId())) {
+            throw new CustomException(Result.UNAUTHORIZED_USER);
+        }
+
+        bookmarkRepository.delete(bookmark);
+        return BookmarkingResponse.of(bookmark.getBookmarkId(), user.getUserId());
+    }
+}

--- a/server-api/src/main/java/com/depromeet/domains/store/controller/StoreController.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/controller/StoreController.java
@@ -32,7 +32,7 @@ public class StoreController {
 		return CustomResponseEntity.success(storeService.getStoreReport(storeId));
 	}
 
-	@GetMapping("/stores/{storeId}/logs")
+	@GetMapping("/stores/{storeId}/reviews")
 	public CustomResponseEntity<Slice<StoreReviewResponse>> getStoreReview(@PathVariable Long storeId, @RequestParam("type") String type, Pageable pageable) {
 		return CustomResponseEntity.success(storeService.getStoreReview(storeId, type, pageable));
 	}

--- a/server-api/src/main/java/com/depromeet/domains/store/controller/StoreController.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/controller/StoreController.java
@@ -1,9 +1,19 @@
 package com.depromeet.domains.store.controller;
 
+import com.depromeet.annotation.AuthUser;
+import com.depromeet.common.exception.CustomResponseEntity;
+import com.depromeet.domains.store.dto.response.StoreLogResponse;
+import com.depromeet.domains.store.dto.response.StorePreviewResponse;
+import com.depromeet.domains.store.dto.response.StoreReportResponse;
 import com.depromeet.domains.store.service.StoreService;
+import com.depromeet.domains.user.entity.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
@@ -14,8 +24,20 @@ public class StoreController {
 
 	private final StoreService storeService;
 
-	@GetMapping("/stores")
-	public ResponseEntity getStores() {
-		return ResponseEntity.status(HttpStatus.OK).body(this.storeService.findAll());
+	@GetMapping("/stores/{storeId}")
+	public CustomResponseEntity<StorePreviewResponse> getStore(@PathVariable Long storeId, @AuthUser User user) {
+		return CustomResponseEntity.success(storeService.getStore(storeId, user));
 	}
+
+	@GetMapping("/stores/{storeId}/reports")
+	public CustomResponseEntity<StoreReportResponse> getStoreReport(@PathVariable Long storeId) {
+		return CustomResponseEntity.success(storeService.getStoreReport(storeId));
+	}
+
+	@GetMapping("/stores/{storeId}/logs")
+	public CustomResponseEntity<Slice<StoreLogResponse>> getStoreLog(@PathVariable Long storeId, @RequestParam("type") String type, Pageable pageable) {
+		return CustomResponseEntity.success(storeService.getStoreLog(storeId, type, pageable));
+	}
+
+
 }

--- a/server-api/src/main/java/com/depromeet/domains/store/controller/StoreController.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/controller/StoreController.java
@@ -2,15 +2,13 @@ package com.depromeet.domains.store.controller;
 
 import com.depromeet.annotation.AuthUser;
 import com.depromeet.common.exception.CustomResponseEntity;
-import com.depromeet.domains.store.dto.response.StoreLogResponse;
 import com.depromeet.domains.store.dto.response.StorePreviewResponse;
 import com.depromeet.domains.store.dto.response.StoreReportResponse;
+import com.depromeet.domains.store.dto.response.StoreReviewResponse;
 import com.depromeet.domains.store.service.StoreService;
 import com.depromeet.domains.user.entity.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -35,8 +33,8 @@ public class StoreController {
 	}
 
 	@GetMapping("/stores/{storeId}/logs")
-	public CustomResponseEntity<Slice<StoreLogResponse>> getStoreLog(@PathVariable Long storeId, @RequestParam("type") String type, Pageable pageable) {
-		return CustomResponseEntity.success(storeService.getStoreLog(storeId, type, pageable));
+	public CustomResponseEntity<Slice<StoreReviewResponse>> getStoreReview(@PathVariable Long storeId, @RequestParam("type") String type, Pageable pageable) {
+		return CustomResponseEntity.success(storeService.getStoreReview(storeId, type, pageable));
 	}
 
 

--- a/server-api/src/main/java/com/depromeet/domains/store/dto/response/StoreLogResponse.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/dto/response/StoreLogResponse.java
@@ -1,0 +1,32 @@
+package com.depromeet.domains.store.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class StoreLogResponse {
+
+    private Long userId;
+    private String nickName;
+    private Float rating;
+    private String imageUrl;
+    private Integer visitTimes;
+    private LocalDateTime visitedAt;
+    private String description;
+
+    public static StoreLogResponse of(Long userId, String nickName, Float rating, String imageUrl, Integer visitTimes, LocalDateTime visitedAt, String description) {
+        return StoreLogResponse.builder()
+                .userId(userId)
+                .nickName(nickName)
+                .rating(rating)
+                .imageUrl(imageUrl)
+                .visitTimes(visitTimes)
+                .visitedAt(visitedAt)
+                .description(description)
+                .build();
+    }
+
+}

--- a/server-api/src/main/java/com/depromeet/domains/store/dto/response/StorePreviewResponse.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/dto/response/StorePreviewResponse.java
@@ -1,0 +1,37 @@
+package com.depromeet.domains.store.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class StorePreviewResponse {
+
+    private Long storeId;
+    private Long categoryId;
+    private String storeName;
+    private String address;
+    private Float starRating;
+    private Long logCount;
+    private List<String> logImageUrls;
+    private Long userId;
+    private Long revisitedCount; // 자신이 재방문한 횟수(N번 방문)
+    private Long totalRevisitedCount; // 전체 재방문 인원 수(00명이 재방문했어요)
+
+    public static StorePreviewResponse of(Long storeId, Long categoryId, String storeName, String address, Float starRating, Long logCount, List<String> logImageUrls, Long userId, Long revisitedCount, Long totalRevisitedCount) {
+        return StorePreviewResponse.builder()
+                .storeId(storeId)
+                .categoryId(categoryId)
+                .storeName(storeName)
+                .address(address)
+                .starRating(starRating)
+                .logCount(logCount)
+                .logImageUrls(logImageUrls)
+                .userId(userId)
+                .revisitedCount(revisitedCount)
+                .totalRevisitedCount(totalRevisitedCount)
+                .build();
+    }
+}

--- a/server-api/src/main/java/com/depromeet/domains/store/dto/response/StorePreviewResponse.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/dto/response/StorePreviewResponse.java
@@ -14,21 +14,21 @@ public class StorePreviewResponse {
     private String storeName;
     private String address;
     private Float starRating;
-    private Long logCount;
-    private List<String> logImageUrls;
+    private Long reviewCount;
+    private List<String> reviewImageUrls;
     private Long userId;
     private Long revisitedCount; // 자신이 재방문한 횟수(N번 방문)
     private Long totalRevisitedCount; // 전체 재방문 인원 수(00명이 재방문했어요)
 
-    public static StorePreviewResponse of(Long storeId, Long categoryId, String storeName, String address, Float starRating, Long logCount, List<String> logImageUrls, Long userId, Long revisitedCount, Long totalRevisitedCount) {
+    public static StorePreviewResponse of(Long storeId, Long categoryId, String storeName, String address, Float starRating, Long reviewCount, List<String> reviewImageUrls, Long userId, Long revisitedCount, Long totalRevisitedCount) {
         return StorePreviewResponse.builder()
                 .storeId(storeId)
                 .categoryId(categoryId)
                 .storeName(storeName)
                 .address(address)
                 .starRating(starRating)
-                .logCount(logCount)
-                .logImageUrls(logImageUrls)
+                .reviewCount(reviewCount)
+                .reviewImageUrls(reviewImageUrls)
                 .userId(userId)
                 .revisitedCount(revisitedCount)
                 .totalRevisitedCount(totalRevisitedCount)

--- a/server-api/src/main/java/com/depromeet/domains/store/dto/response/StoreReportResponse.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/dto/response/StoreReportResponse.java
@@ -8,12 +8,14 @@ import lombok.Getter;
 public class StoreReportResponse {
 
     private Long storeId;
+    private String storeMainImageUrl;
     private Long mostVisitedCount;
     private Long totalRevisitedCount;
 
-    public static StoreReportResponse of(Long storeId, Long mostVisitedCount, Long totalRevisitedCount) {
+    public static StoreReportResponse of(Long storeId, String storeMainImageUrl, Long mostVisitedCount, Long totalRevisitedCount) {
         return StoreReportResponse.builder()
                 .storeId(storeId)
+                .storeMainImageUrl(storeMainImageUrl)
                 .mostVisitedCount(mostVisitedCount)
                 .totalRevisitedCount(totalRevisitedCount)
                 .build();

--- a/server-api/src/main/java/com/depromeet/domains/store/dto/response/StoreReportResponse.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/dto/response/StoreReportResponse.java
@@ -1,0 +1,21 @@
+package com.depromeet.domains.store.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StoreReportResponse {
+
+    private Long storeId;
+    private Long mostVisitedCount;
+    private Long totalRevisitedCount;
+
+    public static StoreReportResponse of(Long storeId, Long mostVisitedCount, Long totalRevisitedCount) {
+        return StoreReportResponse.builder()
+                .storeId(storeId)
+                .mostVisitedCount(mostVisitedCount)
+                .totalRevisitedCount(totalRevisitedCount)
+                .build();
+    }
+}

--- a/server-api/src/main/java/com/depromeet/domains/store/dto/response/StoreReviewResponse.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/dto/response/StoreReviewResponse.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
-public class StoreLogResponse {
+public class StoreReviewResponse {
 
     private Long userId;
     private String nickName;
@@ -17,8 +17,8 @@ public class StoreLogResponse {
     private LocalDateTime visitedAt;
     private String description;
 
-    public static StoreLogResponse of(Long userId, String nickName, Float rating, String imageUrl, Integer visitTimes, LocalDateTime visitedAt, String description) {
-        return StoreLogResponse.builder()
+    public static StoreReviewResponse of(Long userId, String nickName, Float rating, String imageUrl, Integer visitTimes, LocalDateTime visitedAt, String description) {
+        return StoreReviewResponse.builder()
                 .userId(userId)
                 .nickName(nickName)
                 .rating(rating)

--- a/server-api/src/main/java/com/depromeet/domains/store/service/StoreService.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/service/StoreService.java
@@ -1,20 +1,104 @@
 package com.depromeet.domains.store.service;
 
-import com.depromeet.domains.store.repository.StoreFinder;
+import com.depromeet.common.exception.CustomException;
+import com.depromeet.common.exception.Result;
+import com.depromeet.domains.review.entity.Review;
+import com.depromeet.domains.review.repository.ReviewRepository;
+import com.depromeet.domains.store.dto.response.StoreLogResponse;
+import com.depromeet.domains.store.dto.response.StorePreviewResponse;
+import com.depromeet.domains.store.dto.response.StoreReportResponse;
 import com.depromeet.domains.store.entity.Store;
+import com.depromeet.domains.store.repository.StoreRepository;
+import com.depromeet.domains.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class StoreService {
 
-	private final StoreFinder storeFinder;
+	private final StoreRepository storeRepository;
+	private final ReviewRepository reviewRepository;
 
-	public List<Store> findAll() {
-		return this.storeFinder.findAll();
+	@Transactional(readOnly = true)
+	public StorePreviewResponse getStore(Long storeId, User user) {
+
+		Store store = storeRepository.findById(storeId).orElseThrow(() -> new CustomException(Result.NOT_FOUND_STORE));
+		List<Review> reviews = reviewRepository.findTop10ByStoreOrderByCreatedAtDesc(store);
+
+		ArrayList<String> logImageUrls = new ArrayList<>();
+		for (Review review : reviews) {
+			logImageUrls.add(review.getImageUrl());
+		}
+
+		Long revisitedCount = reviewRepository.countByStoreAndUser(store, user);
+		Long totalRevisitedCount = reviewRepository.countTotalRevisitedCount(store);
+
+		return StorePreviewResponse.of(
+				store.getStoreId(),
+				store.getCategory().getCategoryId(),
+				store.getStoreName(),
+				store.getRoadAddress(),
+				store.getTotalRating(),
+				store.getTotalReviewCount(),
+				logImageUrls,
+				user.getUserId(),
+				revisitedCount,
+				totalRevisitedCount);
 	}
 
+	@Transactional(readOnly = true)
+	public StoreReportResponse getStoreReport(Long storeId) {
+		Store store = storeRepository.findById(storeId).orElseThrow(() -> new CustomException(Result.NOT_FOUND_STORE));
+
+		Long mostVisitedCount = reviewRepository.maxReviewCount(store);
+		Long totalRevisitedCount = reviewRepository.countTotalRevisitedCount(store);
+
+		return StoreReportResponse.of(
+				store.getStoreId(),
+				mostVisitedCount,
+				totalRevisitedCount);
+	}
+
+	@Transactional(readOnly = true)
+	public Slice<StoreLogResponse> getStoreLog(Long storeId, String type, Pageable pageable) {
+
+		Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
+		PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
+
+		Store store = storeRepository.findById(storeId).orElseThrow(() -> new CustomException(Result.NOT_FOUND_STORE));
+
+		List<Review> reviews = new ArrayList<>();
+		if (type.equals("revisit")) {
+			reviews = reviewRepository.findRevisitedReviews(store);
+		} else if (type.equals("photo")) {
+			reviews = reviewRepository.findByImageUrlIsNotNullOrderByCreatedAtDesc();
+		}
+
+		// Review 객체를 StoreLogResponse DTO로 변환
+		List<StoreLogResponse> storeLogResponses = getStoreLogResponses(reviews);
+
+		// Slice 객체 생성
+		return new SliceImpl<>(storeLogResponses, pageable, storeLogResponses.size() == pageable.getPageSize());
+	}
+
+	private static List<StoreLogResponse> getStoreLogResponses(List<Review> reviews) {
+		List<StoreLogResponse> storeLogResponses = reviews.stream()
+				.map(review -> StoreLogResponse.of(
+						review.getUser().getUserId(),
+						review.getUser().getNickName(),
+						review.getRating(),
+						review.getImageUrl(),
+						review.getVisitTimes(),
+						review.getVisitedAt(),
+						review.getDescription()))
+				.collect(Collectors.toList());
+		return storeLogResponses;
+	}
 }

--- a/server-api/src/main/java/com/depromeet/domains/store/service/StoreService.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/service/StoreService.java
@@ -62,6 +62,7 @@ public class StoreService {
 
 		return StoreReportResponse.of(
 				store.getStoreId(),
+				store.getThumbnailUrl(),
 				mostVisitedCount,
 				totalRevisitedCount);
 	}

--- a/server-api/src/main/java/com/depromeet/domains/store/service/StoreService.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/service/StoreService.java
@@ -4,9 +4,9 @@ import com.depromeet.common.exception.CustomException;
 import com.depromeet.common.exception.Result;
 import com.depromeet.domains.review.entity.Review;
 import com.depromeet.domains.review.repository.ReviewRepository;
-import com.depromeet.domains.store.dto.response.StoreLogResponse;
 import com.depromeet.domains.store.dto.response.StorePreviewResponse;
 import com.depromeet.domains.store.dto.response.StoreReportResponse;
+import com.depromeet.domains.store.dto.response.StoreReviewResponse;
 import com.depromeet.domains.store.entity.Store;
 import com.depromeet.domains.store.repository.StoreRepository;
 import com.depromeet.domains.user.entity.User;
@@ -67,7 +67,7 @@ public class StoreService {
 	}
 
 	@Transactional(readOnly = true)
-	public Slice<StoreLogResponse> getStoreLog(Long storeId, String type, Pageable pageable) {
+	public Slice<StoreReviewResponse> getStoreReview(Long storeId, String type, Pageable pageable) {
 
 		Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
 		PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
@@ -82,15 +82,15 @@ public class StoreService {
 		}
 
 		// Review 객체를 StoreLogResponse DTO로 변환
-		List<StoreLogResponse> storeLogResponses = getStoreLogResponses(reviews);
+		List<StoreReviewResponse> storeReviewResponse = getStoreLogResponses(reviews);
 
 		// Slice 객체 생성
-		return new SliceImpl<>(storeLogResponses, pageable, storeLogResponses.size() == pageable.getPageSize());
+		return new SliceImpl<>(storeReviewResponse, pageable, storeReviewResponse.size() == pageable.getPageSize());
 	}
 
-	private static List<StoreLogResponse> getStoreLogResponses(List<Review> reviews) {
-		List<StoreLogResponse> storeLogResponses = reviews.stream()
-				.map(review -> StoreLogResponse.of(
+	private static List<StoreReviewResponse> getStoreLogResponses(List<Review> reviews) {
+		List<StoreReviewResponse> storeLogResponses = reviews.stream()
+				.map(review -> StoreReviewResponse.of(
 						review.getUser().getUserId(),
 						review.getUser().getNickName(),
 						review.getRating(),

--- a/server-common/src/main/java/com/depromeet/common/exception/Result.java
+++ b/server-common/src/main/java/com/depromeet/common/exception/Result.java
@@ -9,7 +9,10 @@ public enum Result {
     LOGOUT_OK(200, "로그아웃 성공"),
     DELETE_OK(200, "회원 탈퇴 성공"),
     FAIL(400, "실패"),
-    BAD_REQUEST(400,"잘못된 요청");
+    BAD_REQUEST(400,"잘못된 요청"),
+    UNAUTHORIZED_USER(403, "권한 없는 사용자"),
+    NOT_FOUND_BOOKMARK(404, "북마크를 찾을 수 없습니다."),
+    NOT_FOUND_STORE(404, "가게를 찾을 수 없습니다."),;
 
 
 

--- a/server-domain/src/main/java/com/depromeet/domains/bookmark/entity/Bookmark.java
+++ b/server-domain/src/main/java/com/depromeet/domains/bookmark/entity/Bookmark.java
@@ -2,27 +2,27 @@ package com.depromeet.domains.bookmark.entity;
 
 import com.depromeet.domains.common.entity.BaseTimeEntity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.depromeet.domains.store.entity.Store;
+import com.depromeet.domains.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Builder
+@AllArgsConstructor
 public class Bookmark extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long bookmarkId;
 
-	@Column(nullable = false)
-	private String userId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
 
-	@Column(nullable = false)
-	private String storeId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "store_id")
+	private Store store;
 }

--- a/server-domain/src/main/java/com/depromeet/domains/follow/entity/Follow.java
+++ b/server-domain/src/main/java/com/depromeet/domains/follow/entity/Follow.java
@@ -2,11 +2,8 @@ package com.depromeet.domains.follow.entity;
 
 import com.depromeet.domains.common.entity.BaseTimeEntity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.depromeet.domains.user.entity.User;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,9 +17,11 @@ public class Follow extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long followId;
 
-	@Column(nullable = false)
-	private Long followerId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "following_id", referencedColumnName = "user_id")
+	private User following; //일반유저
 
-	@Column(nullable = false)
-	private Long followingId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "followed_id", referencedColumnName = "user_id")
+	private User followed; //크리에이터
 }

--- a/server-domain/src/main/java/com/depromeet/domains/heart/entity/Heart.java
+++ b/server-domain/src/main/java/com/depromeet/domains/heart/entity/Heart.java
@@ -2,11 +2,9 @@ package com.depromeet.domains.heart.entity;
 
 import com.depromeet.domains.common.entity.BaseTimeEntity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.depromeet.domains.review.entity.Review;
+import com.depromeet.domains.user.entity.User;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,9 +18,11 @@ public class Heart extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long heartId;
 
-	@Column(name = "image", columnDefinition = "varchar(500) null comment '이미지'")
-	private Long userId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
 
-	@Column(nullable = false)
-	private Long ddoeatlogId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "review_id")
+	private Review review;
 }

--- a/server-domain/src/main/java/com/depromeet/domains/review/entity/Review.java
+++ b/server-domain/src/main/java/com/depromeet/domains/review/entity/Review.java
@@ -4,11 +4,9 @@ import java.time.LocalDateTime;
 
 import com.depromeet.domains.common.entity.BaseTimeEntity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.depromeet.domains.store.entity.Store;
+import com.depromeet.domains.user.entity.User;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,11 +20,13 @@ public class Review extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long reviewId;
 
-	@Column(nullable = false)
-	private Long storeId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "store_id")
+	private Store store;
 
-	@Column(nullable = false)
-	private Long userId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
 
 	@Column(nullable = false)
 	private Float rating;

--- a/server-domain/src/main/java/com/depromeet/domains/review/repository/ReviewRepository.java
+++ b/server-domain/src/main/java/com/depromeet/domains/review/repository/ReviewRepository.java
@@ -1,7 +1,38 @@
 package com.depromeet.domains.review.repository;
 
 import com.depromeet.domains.review.entity.Review;
+import com.depromeet.domains.store.entity.Store;
+import com.depromeet.domains.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    //리뷰 이미지가 존재하는 가장 최근 10개의 리뷰 조회
+    List<Review> findTop10ByStoreOrderByCreatedAtDesc(Store store);
+
+    // 자신이 특정 음식점에 몇번째 재방문인지 조회
+    Long countByStoreAndUser(Store store, User user);
+
+    // 특정 음식점에 전체 재방문 인원 조회
+    @Query("SELECT COUNT(DISTINCT r.user) FROM Review r WHERE r.store = :store GROUP BY r.user HAVING COUNT(r) >= 2")
+    Long countTotalRevisitedCount(@Param("store") Store store);
+
+    // 맛집 최고의 단골의 방문 수
+    @Query("SELECT MAX(r.visitCount) FROM (SELECT COUNT(r) as visitCount FROM Review r WHERE r.store = :store GROUP BY r.user) AS r")
+    Long maxReviewCount(@Param("store") Store store);
+
+    // 재방문 리뷰만 조회
+    @Query("SELECT r FROM Review r WHERE r.store = :store AND r.user IN " +
+            "(SELECT u FROM Review u WHERE u.store = :store GROUP BY u.user HAVING COUNT(u) >= 2) " +
+            "ORDER BY r.createdAt DESC")
+    List<Review> findRevisitedReviews(@Param("store") Store store);
+
+    // 사진 리뷰만 조회
+    List<Review> findByImageUrlIsNotNullOrderByCreatedAtDesc();
+
+
 }

--- a/server-domain/src/main/java/com/depromeet/domains/store/entity/Store.java
+++ b/server-domain/src/main/java/com/depromeet/domains/store/entity/Store.java
@@ -1,13 +1,9 @@
 package com.depromeet.domains.store.entity;
 
+import com.depromeet.domains.category.entity.Category;
 import com.depromeet.domains.common.entity.BaseTimeEntity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,8 +21,9 @@ public class Store extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long storeId;
 
-	@Column(nullable = false)
-	private Long categoryId;
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "category_id")
+	private Category category;
 
 	@Column(nullable = false)
 	private String storeName;
@@ -44,4 +41,8 @@ public class Store extends BaseTimeEntity {
 	private String roadAddress;
 
 	private String addressDetail;
+
+	private Float totalRating;
+
+	private Long totalReviewCount;
 }

--- a/server-domain/src/main/java/com/depromeet/domains/user/entity/User.java
+++ b/server-domain/src/main/java/com/depromeet/domains/user/entity/User.java
@@ -23,6 +23,7 @@ public class User extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "user_id")
 	private Long userId;
 
 	@Enumerated(EnumType.STRING)

--- a/server-domain/src/main/resources/data.sql
+++ b/server-domain/src/main/resources/data.sql
@@ -1,0 +1,8 @@
+INSERT INTO Category (categoryId, categoryName, createdAt) VALUES (1, '일식', NOW());
+INSERT INTO Category (categoryId, categoryName, createdAt) VALUES (2, '카페', NOW());
+
+INSERT INTO Store (storeId, category_id, storeName, latitude, longitude, thumbnailUrl, jibunAddress, roadAddress, addressDetail, totalRating, totalReviewCount, createdAt, updateAt)
+VALUES (1, 1, '맛집1', 37.5665, 126.9780, 'thumbnail1.jpg', '서울특별시 중구 세종대로 110', '서울특별시 중구 세종대로 110', '101호', 4.5, 100, NOW(), NOW());
+
+INSERT INTO Store (storeId, category_id, storeName, latitude, longitude, thumbnailUrl, jibunAddress, roadAddress, addressDetail, totalRating, totalReviewCount, createdAt, updateAt)
+VALUES (2, 2, '카페2', 37.5651, 126.98955, 'thumbnail2.jpg', '서울특별시 중구 청계천로 100', '서울특별시 중구 청계천로 100', '201호', 4.0, 80, NOW(), NOW());


### PR DESCRIPTION
### ✅ PR 타입 & 이슈번호
가게 정보 조회 (#28)
가게 상세 조회 (#29)

### 📌 상세 내용
- 핀 클릭시 가게 정보 프리뷰 화면 조회
- 가게 상세 조회 시 또잇 로그 조회
- 가게 상세 조회 시 로그에 대해 재방문자, 사진만을 쿼리스트링을 이용하여 구분
- jpql을 이용한 복잡한 쿼리 메서드 생성

### 🔥 궁금한점



