### PR TITLE
Feature/#14 Jacoco 설정

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/server-api/build.gradle
+++ b/server-api/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
+    id 'jacoco'
 }
 
 processResources.dependsOn('copySecret')
@@ -72,6 +73,7 @@ test {
     // 위에서 작성한 snippetsDir 디렉토리를 test의 output으로 구성하는 설정 -> 스니펫 조각들이 build/generated-snippets로 출력
     outputs.dir snippetsDir
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport' // test 실행 -> jacocoTestReport 실행 위해
 }
 
 asciidoctor { // asciidoctor 작업 구성
@@ -105,6 +107,66 @@ task copyDocument(type: Copy) {
 // build 의 의존작업 명시
 build {
     dependsOn copyDocument
+}
+
+jacocoTestReport {
+    reports {
+        html.required = true // html 설정
+        html.destination file('build/reports/testResult.html')
+        csv.required = true // csv 설정
+        xml.required = false // xml 미설정
+    }
+
+    def Qdomains = []
+    for (qPattern in "**/QA".."**/QZ") {
+        Qdomains.add(qPattern + "*")
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it,
+                    exclude: [] + Qdomains)
+        }))
+    }
+
+    finalizedBy 'jacocoTestCoverageVerification' // jacocoTestReport 실행 -> jacocoTestCoverageVerification 실행 위해
+}
+
+jacoco {
+    toolVersion = '0.8.7' // 작성일(20.10.05) 기준
+    // reportsDir = ${project.reporting.baseDir}/jacoco
+}
+
+jacocoTestCoverageVerification {
+    // 추후에 QueryDsl 사용하게 되었을 때 자동생성되는 Qxxx 클래스 제외.
+    def Qdomains = []
+    for (qPattern in "*.QA".."*.QZ") {  // qPattern = "*.QA","*.QB","*.QC", ... "*.QZ"
+        Qdomains.add(qPattern + "*")
+    }
+
+    violationRules {
+        rule {
+            enabled = true // 활성화
+            element = 'CLASS' // 클래스 단위로 커버리지 체크
+            // includes = []
+
+            // 라인 커버리지 제한을 80%로 설정 (-> 추후 조정)
+            limit {
+                counter = 'LINE' // 빈 줄을 제외한 실제 코드의 라인 수, 라인이 한 번이라도 실행되면 실행된 것으로 간주한다.
+                value = 'COVEREDRATIO'  // 커버된 비율, 0부터 1사이의 숫자로 1이 100%이다.
+                minimum = 0.0 // 현재는 0%, 추후에 60 ~ 80%로 설정
+            }
+
+            // 브랜치 커버리지 제한을 80%로 설정
+            limit {
+                counter = 'BRANCH' // 조건문 등의 분기 수
+                value = 'COVEREDRATIO'
+                minimum = 0.0 // 현재는 0%, 추후에 60 ~ 80%로 설정
+            }
+
+            excludes = [] + Qdomains
+        }
+    }
 }
 
 bootJar {

--- a/server-api/build.gradle
+++ b/server-api/build.gradle
@@ -73,7 +73,7 @@ test {
     // 위에서 작성한 snippetsDir 디렉토리를 test의 output으로 구성하는 설정 -> 스니펫 조각들이 build/generated-snippets로 출력
     outputs.dir snippetsDir
     useJUnitPlatform()
-    finalizedBy 'jacocoTestReport' // test 실행 -> jacocoTestReport 실행 위해
+    finalizedBy 'jacocoTestReport' // test 먼저 실행 후 -> jacocoTestReport 실행 위해
 }
 
 asciidoctor { // asciidoctor 작업 구성
@@ -133,7 +133,7 @@ jacocoTestReport {
 }
 
 jacoco {
-    toolVersion = '0.8.7' // 작성일(20.10.05) 기준
+    toolVersion = '0.8.9'
     // reportsDir = ${project.reporting.baseDir}/jacoco
 }
 

--- a/server-api/build.gradle
+++ b/server-api/build.gradle
@@ -112,7 +112,7 @@ build {
 jacocoTestReport {
     reports {
         html.required = true // html 설정
-        html.destination file('build/reports/testResult.html')
+        html.destination file('build/reports/jacocoTestResult')
         csv.required = true // csv 설정
         xml.required = false // xml 미설정
     }
@@ -154,14 +154,14 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'LINE' // 빈 줄을 제외한 실제 코드의 라인 수, 라인이 한 번이라도 실행되면 실행된 것으로 간주한다.
                 value = 'COVEREDRATIO'  // 커버된 비율, 0부터 1사이의 숫자로 1이 100%이다.
-                minimum = 0.0 // 현재는 0%, 추후에 60 ~ 80%로 설정
+                minimum = 0.0 // 현재는 0%, 추후에 60 ~ 80%로 설정. 80% 이려면 0.8
             }
 
             // 브랜치 커버리지 제한을 80%로 설정
             limit {
                 counter = 'BRANCH' // 조건문 등의 분기 수
                 value = 'COVEREDRATIO'
-                minimum = 0.0 // 현재는 0%, 추후에 60 ~ 80%로 설정
+                minimum = 0.0 // 현재는 0%, 추후에 60 ~ 80%로 설정. 80% 이려면 0.8
             }
 
             excludes = [] + Qdomains


### PR DESCRIPTION
### ✅ PR 타입 & 이슈번호
ex) 기능 추가 (#8)

### 📌 상세 내용
- 실행방법(노션에도 정리해놨습니다)
```linux
./gradlew clean --console verbose test 
```
- `--console verbose` 옵션 추가하면 실행되는 Task를 함께 볼 수 있어요.
- 위 명령어 실행하면 gradle(api 모듈 밑) build/reports/jacocoTestResult 에 설정한 것처럼, 저기 위치 가면(api 모듈 밑의 build 폴더) 파일들이 생겨요.
- 거기 들어가보면 여러 테스트 파일이 어떻게 이루어졌는지 알 수 있어요.
- build.gradle 에서 jacocoTestReport 는 저희가 눈으로 볼 Report 만드는 것이고, jacocoTestCoverageVerification 는 실제로 커버리지가 어느 정도 커버 됐는지 측정하는 거에요.
- Qxx 머시기는 추후에 QueryDsl 사용하게 되었을 때 자동생성되는 Qxxx 클래스 제외하는 것입니다.
- lombok.config 파일과 내용은, lombok 에 의해 generated 된 setter 메서드 같은 것들은 테스트 커버리지에서 제외하는 것!
- 그리고 현재는 목표 테스트 커버리지를 0으로 설정해놨어요. 0.3 (30%) 로 하더라도 어떤 곳은 0.2밖에 안되서 빌드가 실패하더라구요. 
만약 실패하면 `lines covered ratio is 0.2, but expected minimum is 0.3` 이런식으로 경고 뜹니다.

### 🔥 궁금한점 (+ 고려)
- 일단 로컬에서 실행해서 보면 보이는데, 저런 식으로 말고 Sonar Qube? 로 모니터링까지 하는 방법도 있던데 아직 그 설정은 하지 않았습니다. 다른 팀들은 Jacobo 쓴다면 어디까지 설정하는지 궁금하네요
- 그리고 저희 api 모듈 안에서도 어디까지 테스트 범위안에 포함시켜야 하는지는 구체적으로 설정하진 않았습니다. 저희 테스트 코드 (유닛, 서비스 layer 등) 를 어느 범위까지 ? 작성할 것인가. 아직 잘 몰라서요!



