### PR TITLE
[Feature/#37] 로그인 인증 관련 로직 추가

### DIFF
--- a/server-api/src/main/java/com/depromeet/auth/controller/AuthController.java
+++ b/server-api/src/main/java/com/depromeet/auth/controller/AuthController.java
@@ -6,9 +6,14 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.depromeet.annotation.AuthUser;
 import com.depromeet.auth.dto.TokenResponse;
 import com.depromeet.auth.service.AuthService;
+import com.depromeet.auth.service.CookieService;
+import com.depromeet.common.exception.CustomResponseEntity;
+import com.depromeet.domains.user.entity.User;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
 
@@ -17,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping(value = "/api/v1/auth")
 public class AuthController {
 	private final AuthService authService;
+	private final CookieService cookieService;
 
 	/**
 	 * Refresh Token으로 사용자 Access Token 갱신 요청
@@ -27,5 +33,15 @@ public class AuthController {
 	) throws IllegalAccessException {
 		TokenResponse response = authService.reissueToken(refreshToken);
 		return ResponseEntity.ok(response);
+	}
+
+	@PostMapping("/signup")
+	public CustomResponseEntity<Object> signup(@AuthUser User user, HttpServletResponse response
+	) throws IllegalAccessException {
+		TokenResponse tokenResponse = authService.signup(user.getUserId());
+		// 응답 헤더에 쿠키 추가
+		response.addCookie(cookieService.createAccessTokenCookie(tokenResponse.getAccessToken()));
+		response.addCookie(cookieService.createRefreshTokenCookie(tokenResponse.getRefreshToken()));
+		return CustomResponseEntity.success();
 	}
 }

--- a/server-api/src/main/java/com/depromeet/auth/jwt/JwtService.java
+++ b/server-api/src/main/java/com/depromeet/auth/jwt/JwtService.java
@@ -133,7 +133,7 @@ public class JwtService {
 
 	private Collection<GrantedAuthority> getAuthorities(User user) {
 		return Collections.singletonList(
-			new SimpleGrantedAuthority(user.getUserRole().toString())
+			new SimpleGrantedAuthority("ROLE_" + user.getUserRole().toString())
 		);
 	}
 

--- a/server-api/src/main/java/com/depromeet/auth/oauth2/CustomOAuth2User.java
+++ b/server-api/src/main/java/com/depromeet/auth/oauth2/CustomOAuth2User.java
@@ -6,11 +6,14 @@ import java.util.Map;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 
+import com.depromeet.enums.Role;
+
 import lombok.Getter;
 
 @Getter
 public class CustomOAuth2User extends DefaultOAuth2User {
 	private final Long userId;
+	private final Role userRole;
 
 	/**
 	 * Constructs a {@code DefaultOAuth2User} using the provided parameters.
@@ -21,8 +24,9 @@ public class CustomOAuth2User extends DefaultOAuth2User {
 	 *                         {@link #getAttributes()}
 	 */
 	public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities,
-		Map<String, Object> attributes, String nameAttributeKey, Long userId) {
+		Map<String, Object> attributes, String nameAttributeKey, Long userId, Role userRole) {
 		super(authorities, attributes, nameAttributeKey);
 		this.userId = userId;
+		this.userRole = userRole;
 	}
 }

--- a/server-api/src/main/java/com/depromeet/auth/oauth2/OAuth2Attribute.java
+++ b/server-api/src/main/java/com/depromeet/auth/oauth2/OAuth2Attribute.java
@@ -46,12 +46,9 @@ public class OAuth2Attribute {
 
 	private static OAuth2Attribute ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
 		Map<String, Object> kakaoAccount = (Map<String, Object>)attributes.get("kakao_account");
-		Map<String, Object> kakaoProfile = (Map<String, Object>)kakaoAccount.get("profile");
 
 		return OAuth2Attribute.builder()
 			.socialId(String.valueOf(attributes.get("id")))
-			.nickname((String)kakaoProfile.get("nickname"))
-			.email((String)kakaoAccount.get("email"))
 			.attributes(kakaoAccount)
 			.nameAttributeKey(userNameAttributeName)
 			.build();
@@ -61,9 +58,8 @@ public class OAuth2Attribute {
 		return User.builder()
 			.socialType(socialType)
 			.socialId(socialId)
-			.nickName(nickname)
-			.email(email)
-			.userRole(Role.USER)
+			.nickName("게스트"+socialId)
+			.userRole(Role.GUEST)
 			.build();
 	}
 }

--- a/server-api/src/main/java/com/depromeet/auth/oauth2/handler/CustomOAuth2FailureHandler.java
+++ b/server-api/src/main/java/com/depromeet/auth/oauth2/handler/CustomOAuth2FailureHandler.java
@@ -6,22 +6,30 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
-import com.depromeet.auth.jwt.JwtService;
 import com.depromeet.common.exception.CustomException;
 import com.depromeet.common.exception.Result;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class CustomOAuth2FailureHandler implements AuthenticationFailureHandler {
 
 	@Override
 	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
 		AuthenticationException exception) throws IOException, ServletException {
-		throw new CustomException(Result.BAD_REQUEST);
+		response.setContentType("application/json");
+		response.setStatus(Result.SOCIAL_LOGIN_FAIL.getCode());
+		ObjectMapper objectMapper = new ObjectMapper();
+		response.getWriter().write(objectMapper.writeValueAsString(
+			new CustomException(Result.SOCIAL_LOGIN_FAIL)
+		));
+		log.info("소셜 로그인에 실패했습니다. 에러 메시지 : {}", exception.getMessage());
 	}
 }

--- a/server-api/src/main/java/com/depromeet/auth/oauth2/handler/CustomOAuth2SuccessHandler.java
+++ b/server-api/src/main/java/com/depromeet/auth/oauth2/handler/CustomOAuth2SuccessHandler.java
@@ -2,12 +2,15 @@ package com.depromeet.auth.oauth2.handler;
 
 import java.io.IOException;
 
-import com.depromeet.auth.oauth2.CustomOAuth2User;
-import com.depromeet.auth.jwt.JwtService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+
+import com.depromeet.auth.jwt.JwtService;
+import com.depromeet.auth.oauth2.CustomOAuth2User;
+import com.depromeet.auth.service.CookieService;
+import com.depromeet.enums.Role;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -18,19 +21,41 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler {
 	private final JwtService jwtService;
-	@Value("${server.url}")
-	private String serverUrl;
+	private final CookieService cookieService;
+
+	@Value("${front.url}")
+	private String frontUrl;
+
+	@Value("${jwt.access.expiration}")
+	private Long accessTokenExpirationPeriod;
 
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
 		Authentication authentication) throws IOException, ServletException {
 		CustomOAuth2User oAuth2User = (CustomOAuth2User)authentication.getPrincipal();
+		System.out.println(oAuth2User.getUserRole());
+		if (oAuth2User.getUserRole() == Role.GUEST) {
+			String accessToken = jwtService.createAccessToken(oAuth2User.getUserId());
+			response.addCookie(cookieService.createAccessTokenCookie(accessToken));
+
+			// 약관 동의 페이지로 리다이렉트
+			String targetUrl = frontUrl + "/terms";
+			response.sendRedirect(targetUrl);
+
+		} else {
+			loginSuccess(response, oAuth2User);
+		}
+	}
+
+	private void loginSuccess(HttpServletResponse response, CustomOAuth2User oAuth2User) throws IOException {
 
 		String accessToken = jwtService.createAccessToken(oAuth2User.getUserId());
 		String refreshToken = jwtService.createRefreshToken(oAuth2User.getUserId());
 
-		String redirectURL = serverUrl + "?access_token=" + accessToken + "&refresh_token=" + refreshToken;
+		// 응답 헤더에 쿠키 추가
+		response.addCookie(cookieService.createAccessTokenCookie(accessToken));
+		response.addCookie(cookieService.createRefreshTokenCookie(refreshToken));
 
-		response.sendRedirect(redirectURL);
+		response.sendRedirect(frontUrl);
 	}
 }

--- a/server-api/src/main/java/com/depromeet/auth/oauth2/service/CustomOAuth2UserService.java
+++ b/server-api/src/main/java/com/depromeet/auth/oauth2/service/CustomOAuth2UserService.java
@@ -44,8 +44,8 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 		// 기존 가입된 유저인지 확인
 		User createdUser = getUser(extractAttributes, socialType);
 
-		return new CustomOAuth2User(Collections.singleton(new SimpleGrantedAuthority(createdUser.getUserRole().getKey())),
-			attributes, extractAttributes.getNameAttributeKey(), createdUser.getUserId());
+		return new CustomOAuth2User(Collections.singleton(new SimpleGrantedAuthority(createdUser.getUserRole().getDescription())),
+			attributes, extractAttributes.getNameAttributeKey(), createdUser.getUserId(), createdUser.getUserRole());
 	}
 
 	private String getUserNameAttributeName(final OAuth2UserRequest userRequest) {

--- a/server-api/src/main/java/com/depromeet/auth/service/CookieService.java
+++ b/server-api/src/main/java/com/depromeet/auth/service/CookieService.java
@@ -1,0 +1,33 @@
+package com.depromeet.auth.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.Cookie;
+
+@Component
+public class CookieService {
+	@Value("${jwt.access.expiration}")
+	private Long accessTokenExpirationPeriod;
+
+	@Value("${jwt.refresh.expiration}")
+	private Long refreshTokenExpirationPeriod;
+
+	public Cookie createAccessTokenCookie(String token) {
+		Cookie cookie = new Cookie("accessToken", token);
+		cookie.setPath("/");
+		int accessTokenExpirationInSeconds = (int)(accessTokenExpirationPeriod / 1000);
+		cookie.setMaxAge(accessTokenExpirationInSeconds);
+		cookie.setHttpOnly(true);
+		return cookie;
+	}
+
+	public Cookie createRefreshTokenCookie(String token) {
+		Cookie cookie = new Cookie("refreshToken", token);
+		cookie.setPath("/");
+		int accessTokenExpirationInSeconds = (int)(refreshTokenExpirationPeriod / 1000);
+		cookie.setMaxAge(accessTokenExpirationInSeconds);
+		cookie.setHttpOnly(true);
+		return cookie;
+	}
+}

--- a/server-api/src/main/java/com/depromeet/config/SecurityConfig.java
+++ b/server-api/src/main/java/com/depromeet/config/SecurityConfig.java
@@ -1,11 +1,9 @@
 package com.depromeet.config;
 
-import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
@@ -44,6 +42,8 @@ public class SecurityConfig {
 			)
 			.authorizeHttpRequests(request -> request
 				.requestMatchers(PATTERNS).permitAll()
+				.requestMatchers("/api/v1/auth/signup").hasRole("GUEST")
+
 				.anyRequest().authenticated()
 			)
 			.oauth2Login(oauth2Login ->

--- a/server-common/src/main/java/com/depromeet/common/exception/Result.java
+++ b/server-common/src/main/java/com/depromeet/common/exception/Result.java
@@ -10,9 +10,11 @@ public enum Result {
     DELETE_OK(200, "회원 탈퇴 성공"),
     FAIL(400, "실패"),
     BAD_REQUEST(400,"잘못된 요청"),
+    SOCIAL_LOGIN_FAIL(400, "소셜로그인 실패"),
     UNAUTHORIZED_USER(403, "권한 없는 사용자"),
     NOT_FOUND_BOOKMARK(404, "북마크를 찾을 수 없습니다."),
-    NOT_FOUND_STORE(404, "가게를 찾을 수 없습니다."),;
+    NOT_FOUND_STORE(404, "가게를 찾을 수 없습니다."),
+    NOT_FOUND_USER(404, "사용자를 찾을 수 없습니다." );
 
 
 

--- a/server-domain/src/main/java/com/depromeet/domains/user/entity/User.java
+++ b/server-domain/src/main/java/com/depromeet/domains/user/entity/User.java
@@ -3,6 +3,7 @@ package com.depromeet.domains.user.entity;
 import com.depromeet.domains.common.entity.BaseTimeEntity;
 import com.depromeet.enums.Role;
 import com.depromeet.enums.SocialType;
+import com.depromeet.enums.UserLevel;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -44,6 +45,13 @@ public class User extends BaseTimeEntity {
 	@Column(nullable = false)
 	private String socialId;
 
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private UserLevel level = UserLevel.LEVEL1;
+
+	@Column(nullable = false)
+	private Integer reviewCount = 0;
+
 	@Builder
 	public User(SocialType socialType, String profileImageUrl, String nickName, String email, Role userRole,
 		String socialId) {
@@ -53,5 +61,25 @@ public class User extends BaseTimeEntity {
 		this.email = email;
 		this.userRole = userRole;
 		this.socialId = socialId;
+	}
+
+	public void updateUserRole() {
+		this.userRole = Role.USER;
+	}
+
+	public void updateNickname(String nickName) {
+		this.nickName = nickName;
+	}
+
+	public void updateUserLevel(UserLevel level) {
+		this.level = level;
+	}
+
+	public void increaseReviewCount() {
+		this.reviewCount++;
+	}
+
+	public void decreaseReviewCount() {
+		this.reviewCount = Math.max(0, this.reviewCount - 1);
 	}
 }

--- a/server-domain/src/main/java/com/depromeet/domains/user/repository/UserRepository.java
+++ b/server-domain/src/main/java/com/depromeet/domains/user/repository/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
 
     Optional<User> findByUserId(Long userId);
+
+	boolean existsByNickName(String nickname);
 }

--- a/server-domain/src/main/java/com/depromeet/enums/Role.java
+++ b/server-domain/src/main/java/com/depromeet/enums/Role.java
@@ -1,13 +1,21 @@
 package com.depromeet.enums;
 
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-@Getter
 @RequiredArgsConstructor
-public enum Role {
+public enum Role implements EnumType {
 
-	USER("ROLE_USER"), ADMIN("ROLE_ADMIN");;
+	GUEST("ROLE_GUEST"), USER("ROLE_USER"), ADMIN("ROLE_ADMIN");
 
-	private final String key;
+	private final String description;
+
+	@Override
+	public String getName() {
+		return this.name();
+	}
+
+	@Override
+	public String getDescription() {
+		return this.description;
+	}
 }

--- a/server-domain/src/main/java/com/depromeet/enums/UserLevel.java
+++ b/server-domain/src/main/java/com/depromeet/enums/UserLevel.java
@@ -1,0 +1,23 @@
+package com.depromeet.enums;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum UserLevel implements EnumType {
+    LEVEL1("배고픈"),
+    LEVEL2("맨밥이"),
+    LEVEL3("또밥이"),
+    LEVEL4("또또밥이");
+
+    private final String description;
+
+    @Override
+    public String getName() {
+        return this.name();
+    }
+
+    @Override
+    public String getDescription() {
+        return this.description;
+    }
+}


### PR DESCRIPTION
### ✅ PR 타입 & 이슈번호
기능 수정 (#37)

### 📌 상세 내용
- 사용자 role별 redirect 주소 분기
- 약관 동의 사용자 회원가입 처리 컨트롤러
- 토큰 쿠키에 담아서 발급하는 로직 추가
- 사용자 레벨 추가
- Oauth2 실패 핸들러 수정

### 🔥 궁금한점



