### PR TITLE
Feature/#48 맵 api 수정

### DIFF
--- a/server-api/src/docs/asciidoc/index.adoc
+++ b/server-api/src/docs/asciidoc/index.adoc
@@ -114,6 +114,10 @@ operation::store-controller-test/create-exist-store-review[]
 === 4-2. 리뷰 작성 (새로운 가게)
 operation::store-controller-test/create-new-store-review[]
 
+[[get-location-range-stores]]
+=== 5. 지도에서 위,경도 내에 존재하는 식당정보 조회
+operation::store-controller-test/get-location-range-stores[]
+
 == User API
 
 === 1. 유저 닉네임 변경

--- a/server-api/src/docs/asciidoc/store.adoc
+++ b/server-api/src/docs/asciidoc/store.adoc
@@ -19,3 +19,7 @@ operation::store-controller-test/create-exist-store-review[]
 [[create-new-store-review]]
 === 4-2. 리뷰 작성 (새로운 가게)
 operation::store-controller-test/create-new-store-review[]
+
+[[get-location-range-stores]]
+=== 5. 지도에서 위,경도 내에 존재하는 식당정보 조회
+operation::store-controller-test/get-location-range-stores[]

--- a/server-api/src/main/java/com/depromeet/domains/store/controller/StoreController.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/controller/StoreController.java
@@ -8,14 +8,13 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.depromeet.annotation.AuthUser;
 import com.depromeet.common.exception.CustomResponseEntity;
 import com.depromeet.domains.store.dto.request.ReviewRequest;
-import com.depromeet.domains.store.dto.request.StoreLocationRangeRequest;
 import com.depromeet.domains.store.dto.response.ReviewAddResponse;
 import com.depromeet.domains.store.dto.response.StoreLocationRangeResponse;
 import com.depromeet.domains.store.dto.response.StorePreviewResponse;
@@ -23,6 +22,7 @@ import com.depromeet.domains.store.dto.response.StoreReportResponse;
 import com.depromeet.domains.store.dto.response.StoreReviewResponse;
 import com.depromeet.domains.store.service.StoreService;
 import com.depromeet.domains.user.entity.User;
+import com.depromeet.enums.CategoryType;
 import com.depromeet.enums.ReviewType;
 
 import lombok.RequiredArgsConstructor;
@@ -35,12 +35,17 @@ public class StoreController {
 	private final StoreService storeService;
 
 	@GetMapping("/stores/location-range")
-	public CustomResponseEntity<StoreLocationRangeResponse> getStores(
-		@RequestParam("location1") StoreLocationRangeRequest location1,
-		@RequestParam("location2") StoreLocationRangeRequest location2,
+	public CustomResponseEntity<StoreLocationRangeResponse> getLocationRangeStores(
+		@RequestParam(value = "latitude1") Double latitude1,
+		@RequestParam(value = "longitude1") Double longitude1,
+		@RequestParam(value = "latitude2") Double latitude2,
+		@RequestParam(value = "longitude2") Double longitude2,
+		@RequestParam(value = "level") Integer level,
+		@RequestParam(value = "type") Optional<CategoryType> categoryType,
 		@AuthUser User user) {
-		// return CustomResponseEntity.success(storeService.getRangeStores(location1, location2, user.getUserId()));
-		return CustomResponseEntity.success(null);
+		return CustomResponseEntity.success(
+			storeService.getRangeStores(latitude1, longitude1, latitude2, longitude2, level, categoryType,
+				user));
 	}
 
 	@GetMapping("/stores/{storeId}")
@@ -67,10 +72,10 @@ public class StoreController {
 		return CustomResponseEntity.created(storeService.createStoreReview(user, reviewRequest));
 	}
 
-    //    @DeleteMapping("/stores/{storeId}/reviews/{reviewId}")
-//    public CustomResponseEntity<Void> deleteStoreReview(@AuthUser User user, @PathVariable Long storeId,
-//            @PathVariable Long reviewId) {
-//        storeService.deleteStoreReview(user, storeId, reviewId);
-//        return CustomResponseEntity.success();
-//    }
+	//    @DeleteMapping("/stores/{storeId}/reviews/{reviewId}")
+	//    public CustomResponseEntity<Void> deleteStoreReview(@AuthUser User user, @PathVariable Long storeId,
+	//            @PathVariable Long reviewId) {
+	//        storeService.deleteStoreReview(user, storeId, reviewId);
+	//        return CustomResponseEntity.success();
+	//    }
 }

--- a/server-api/src/main/java/com/depromeet/domains/store/dto/response/StoreLocationRangeResponse.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/dto/response/StoreLocationRangeResponse.java
@@ -8,36 +8,50 @@ import lombok.ToString;
 
 @Getter
 @Builder
-@ToString
+@ToString // 테스트
 public class StoreLocationRangeResponse {
 
-	private List<LocationRangeResponse> response;
+	private List<StoreLocationRange> bookMarkList;
+	private List<StoreLocationRange> locationStoreList;
 
-	public static StoreLocationRangeResponse of(List<LocationRangeResponse> list) {
+	public static StoreLocationRangeResponse of(List<StoreLocationRange> bookMarkList,
+		List<StoreLocationRange> locationStoreList) {
 		return StoreLocationRangeResponse.builder()
-			.response(list)
+			.bookMarkList(bookMarkList)
+			.locationStoreList(locationStoreList)
 			.build();
 	}
 
 	@Getter
 	@Builder
-	public static class LocationRangeResponse {
+	public static class StoreLocationRange {
 		private Long storeId;
+		private Long kakaoStoreId;
 		private String storeName;
+		private Long categoryId;
+		private String categoryName;
+		private String categoryType;
+		private String address;
 		private Double longitude;
 		private Double latitude;
-		private boolean isBookMark;
-		private int totalRevisitedCount;
+		private Long totalRevisitedCount;
+		private Long totalReviewCount;
 
-		public static LocationRangeResponse of(Long storeId, String storeName, Double longitude, Double latitude,
-			boolean isBookMark, int totalRevisitedCount) {
-			return LocationRangeResponse.builder()
+		public static StoreLocationRange of(Long storeId, Long kakaoStoreId, String storeName, Long categoryId,
+			String categoryName, String categoryType, String address, Double longitude, Double latitude,
+			Long totalRevisitedCount, Long totalReviewCount) {
+			return StoreLocationRange.builder()
 				.storeId(storeId)
+				.kakaoStoreId(kakaoStoreId)
 				.storeName(storeName)
+				.categoryId(categoryId)
+				.categoryName(categoryName)
+				.categoryType(categoryType)
+				.address(address)
 				.longitude(longitude)
 				.latitude(latitude)
-				.isBookMark(isBookMark)
 				.totalRevisitedCount(totalRevisitedCount)
+				.totalReviewCount(totalReviewCount)
 				.build();
 		}
 	}

--- a/server-api/src/main/java/com/depromeet/domains/store/service/StoreService.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/service/StoreService.java
@@ -1,14 +1,10 @@
 package com.depromeet.domains.store.service;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import com.depromeet.domains.category.repository.CategoryRepository;
-import com.depromeet.domains.store.entity.StoreMeta;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -16,17 +12,15 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.ObjectUtils;
 
 import com.depromeet.common.exception.CustomException;
 import com.depromeet.common.exception.Result;
 import com.depromeet.domains.category.entity.Category;
+import com.depromeet.domains.category.repository.CategoryRepository;
 import com.depromeet.domains.review.entity.Review;
 import com.depromeet.domains.review.repository.ReviewRepository;
-import com.depromeet.domains.store.dto.StoreLocationDto;
 import com.depromeet.domains.store.dto.request.NewStoreRequest;
 import com.depromeet.domains.store.dto.request.ReviewRequest;
-import com.depromeet.domains.store.dto.request.StoreLocationRangeRequest;
 import com.depromeet.domains.store.dto.response.ReviewAddResponse;
 import com.depromeet.domains.store.dto.response.StoreLocationRangeResponse;
 import com.depromeet.domains.store.dto.response.StorePreviewResponse;
@@ -37,7 +31,9 @@ import com.depromeet.domains.store.entity.StoreMeta;
 import com.depromeet.domains.store.repository.StoreMetaRepository;
 import com.depromeet.domains.store.repository.StoreRepository;
 import com.depromeet.domains.user.entity.User;
+import com.depromeet.enums.CategoryType;
 import com.depromeet.enums.ReviewType;
+import com.depromeet.enums.ViewLevel;
 
 import lombok.RequiredArgsConstructor;
 
@@ -146,87 +142,64 @@ public class StoreService {
 	}
 
 	@Transactional(readOnly = true)
-	public StoreLocationRangeResponse getRangeStores(StoreLocationRangeRequest location1,
-		StoreLocationRangeRequest location2, Long userId) {
+	public StoreLocationRangeResponse getRangeStores(Double latitude1, Double longitude1, Double latitude2,
+		Double longitude2, Integer level, Optional<CategoryType> categoryType, User user) {
 
-		// Double maxLatitude = Double.max(location1.getLatitude(), location2.getLatitude());
-		// Double minLatitude = Double.min(location1.getLatitude(), location2.getLatitude());
-		// Double maxLongitude = Double.max(location1.getLongitude(), location2.getLongitude());
-		// Double minLongitude = Double.min(location1.getLongitude(), location2.getLongitude());
-		//
-		// // 특정 위, 경도 범위 안에 있는 식당 정보 + 해당 user의 북마크 여부
-		// List<Object[]> locationRangesQueryResult =
-		// 	storeRepository.findByLocationRangesWithIsBookmark(maxLatitude, minLatitude, maxLongitude, minLongitude,
-		// 		userId);
-		//
-		// List<StoreLocationDto> locationWithIsBookmarkList = convertToStoreLocationDto(locationRangesQueryResult);
-		//
-		// List<Long> storeIdListWithinRanges = locationWithIsBookmarkList.stream()
-		// 	.map(StoreLocationDto::getStoreId)
-		// 	.collect(Collectors.toList());
-		//
-		// // 위에서 조회한 식당들의 재방문한 사람들의 수
-		// List<Object[]> storesWithRevisitedNumberQueryResult = storeRepository.findByStoresWithNumberOfRevisitedUser(
-		// 	storeIdListWithinRanges);
-		//
-		// return makeStoreLocationRangeResponse(locationWithIsBookmarkList,
-		// 	convertToRevisitedNumberMap(storesWithRevisitedNumberQueryResult));
-		return null;
+		List<Store> bookMarkStoreList = this.storeRepository.findByUsersBookMarkList(user.getUserId());
+		List<Long> bookMarkStoreIdList = storeToIdList(bookMarkStoreList);
+
+		double maxLatitude = Double.max(latitude1, latitude2);
+		double minLatitude = Double.min(latitude1, latitude2);
+		double maxLongitude = Double.max(longitude1, longitude2);
+		double minLongitude = Double.min(longitude1, longitude2);
+
+		ViewLevel viewLevel = ViewLevel.findByLevel(level);
+		CategoryType type = categoryType.isEmpty() ?
+			null : CategoryType.findByType(categoryType.get().getType());
+
+		List<Store> storeList = this.storeRepository.findByLocationRangesWithCategory(
+			maxLatitude, minLatitude, maxLongitude, minLongitude, type, bookMarkStoreIdList);
+
+		int viewStoreListCount = calculateViewStoreListRatio(storeList.size(), viewLevel.getRatio());
+
+		return toStoreLocationRangeResponse(bookMarkStoreList, storeList.subList(0, viewStoreListCount));
 	}
 
-	private StoreLocationRangeResponse makeStoreLocationRangeResponse(List<StoreLocationDto> locationWithIsBookmarkList,
-		Map<Long, Integer> revisitedNumberMap) {
-
-		List<StoreLocationRangeResponse.LocationRangeResponse> result = locationWithIsBookmarkList.stream()
-			.map(row -> StoreLocationRangeResponse.LocationRangeResponse.of(
-				row.getStoreId(),
-				row.getStoreName(),
-				row.getLongitude(),
-				row.getLatitude(),
-				row.isBookMarked(),
-				revisitedNumberMap.get(row.getStoreId()))).collect(Collectors.toList());
-
-		return StoreLocationRangeResponse.of(result);
+	private int calculateViewStoreListRatio(int listSize, double ratio) {
+		return (int)Math.round(listSize * ratio);
 	}
 
-	private Map<Long, Integer> convertToRevisitedNumberMap(List<Object[]> storesWithRevisitedNumberQueryResult) {
-		Map<Long, Integer> revisitedNumberMap = new HashMap<>();
-
-		if (!ObjectUtils.isEmpty(storesWithRevisitedNumberQueryResult)) {
-			storesWithRevisitedNumberQueryResult.stream()
-				.forEach(row -> {
-						Long storeId = (Long)row[0];
-						int numberOfRevisitedUser = Integer.parseInt(String.valueOf(row[2]));
-
-						revisitedNumberMap.put(storeId, numberOfRevisitedUser);
-					}
-				);
-		}
-
-		return revisitedNumberMap;
+	private List<Long> storeToIdList(List<Store> storeList) {
+		return storeList.stream()
+			.map(store -> store.getStoreId())
+			.collect(Collectors.toList());
 	}
 
-	private List<StoreLocationDto> convertToStoreLocationDto(List<Object[]> nativeQueryResult) {
-		List<StoreLocationDto> result = new ArrayList<>();
-		if (!ObjectUtils.isEmpty(nativeQueryResult)) {
-			result = nativeQueryResult.stream()
-				.map(row -> {
-					Long storeId = (Long)row[0];
-					String storeName = (String)row[1];
-					Double latitude = (Double)row[2];
-					Double longitude = (Double)row[3];
-					Long isBookMarkedLongVal = (Long)row[4];
-					boolean isBookmarkedBoolean = false;
-					if (!ObjectUtils.isEmpty(isBookMarkedLongVal) && isBookMarkedLongVal.equals(1L)) {
-						isBookmarkedBoolean = true;
-					}
+	private StoreLocationRangeResponse toStoreLocationRangeResponse(List<Store> bookMarkStoreList,
+		List<Store> locationStoreList) {
 
-					return StoreLocationDto.of(storeId, storeName, latitude, longitude, isBookmarkedBoolean);
-				})
-				.collect(Collectors.toList());
-		}
+		return StoreLocationRangeResponse.builder()
+			.bookMarkList(toStoreLocationRange(bookMarkStoreList))
+			.locationStoreList(toStoreLocationRange(locationStoreList))
+			.build();
+	}
 
-		return result;
+	private List<StoreLocationRangeResponse.StoreLocationRange> toStoreLocationRange(List<Store> storeList) {
+		return storeList.stream()
+			.map(store ->
+				StoreLocationRangeResponse.StoreLocationRange.of(
+					store.getStoreId(),
+					store.getKakaoStoreId(),
+					store.getStoreName(),
+					store.getCategory().getCategoryId(),
+					store.getCategory().getCategoryName(),
+					store.getCategory().getCategoryName(),
+					store.getAddress(),
+					store.getLocation().getLongitude(),
+					store.getLocation().getLatitude(),
+					store.getStoreMeta().getTotalRevisitedCount(),
+					store.getStoreMeta().getTotalReviewCount()))
+			.collect(Collectors.toList());
 	}
 
 	@Transactional
@@ -309,6 +282,7 @@ public class StoreService {
 		reviewRepository.save(review);
 		return review;
 	}
+
 	//	public void deleteStoreReview(User user, Long storeId, Long reviewId) {
 	//		Store store = storeRepository.findById(storeId).orElseThrow(() -> new CustomException(Result.NOT_FOUND_STORE));
 	//		Review review = reviewRepository.findById(reviewId).orElseThrow(() -> new CustomException(Result.NOT_FOUND_REVIEW));

--- a/server-api/src/test/java/com/depromeet/controller/StoreControllerTest.java
+++ b/server-api/src/test/java/com/depromeet/controller/StoreControllerTest.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -28,9 +29,12 @@ import com.depromeet.document.RestDocsTestSupport;
 import com.depromeet.domains.store.dto.request.NewStoreRequest;
 import com.depromeet.domains.store.dto.request.ReviewRequest;
 import com.depromeet.domains.store.dto.response.ReviewAddResponse;
+import com.depromeet.domains.store.dto.response.StoreLocationRangeResponse;
+import com.depromeet.domains.store.dto.response.StoreLocationRangeResponse.StoreLocationRange;
 import com.depromeet.domains.store.dto.response.StorePreviewResponse;
 import com.depromeet.domains.store.dto.response.StoreReportResponse;
 import com.depromeet.domains.store.dto.response.StoreReviewResponse;
+import com.depromeet.enums.CategoryType;
 import com.depromeet.enums.ReviewType;
 
 @AutoConfigureMockMvc
@@ -352,6 +356,164 @@ class StoreControllerTest extends RestDocsTestSupport {
 				)
 			)
 		;
+	}
+
+	@Test
+	@DisplayName("맵의 위경도 내 식당들 정보 조회")
+	public void getLocationRangeStores() throws Exception {
+
+		Double latitude1 = 30.11111;
+		Double longitude1 = 120.0000;
+		Double latitude2 = 60.11111;
+		Double longitude2 = 140.0000;
+		int level = 4;
+		CategoryType type = CategoryType.CAFE;
+		Long userId = 1L; // userId 로 하면 null
+
+		//given
+		StoreLocationRange storeLocationRange1 = StoreLocationRange.builder()
+			.storeId(1L)
+			.kakaoStoreId(2L)
+			.storeName("칠기마라탕1")
+			.categoryId(1L)
+			.categoryName("한식")
+			.categoryType("KOREAN")
+			.address("서울특별시 1")
+			.longitude(127.239487)
+			.latitude(37.29472)
+			.totalRevisitedCount(1L)
+			.totalReviewCount(1L)
+			.build();
+
+		StoreLocationRange storeLocationRange2 = StoreLocationRange.builder()
+			.storeId(2L)
+			.kakaoStoreId(2L)
+			.storeName("칠기마라탕2")
+			.categoryId(1L)
+			.categoryName("중식")
+			.categoryType("CHINESE")
+			.address("서울특별시 2")
+			.longitude(127.239487)
+			.latitude(37.29472)
+			.totalRevisitedCount(1L)
+			.totalReviewCount(1L)
+			.build();
+
+		StoreLocationRange storeLocationRange3 = StoreLocationRange.builder()
+			.storeId(3L)
+			.kakaoStoreId(3L)
+			.storeName("칠기마라탕3")
+			.categoryId(1L)
+			.categoryName("일식")
+			.categoryType("JAPANESE")
+			.address("서울특별시 3")
+			.longitude(127.239487)
+			.latitude(37.29472)
+			.totalRevisitedCount(1L)
+			.totalReviewCount(1L)
+			.build();
+
+		StoreLocationRange storeLocationRange4 = StoreLocationRange.builder()
+			.storeId(4L)
+			.kakaoStoreId(4L)
+			.storeName("칠기마라탕4")
+			.categoryId(1L)
+			.categoryName("양식")
+			.categoryType("WESTERN")
+			.address("서울특별시 4")
+			.longitude(127.239487)
+			.latitude(37.29472)
+			.totalRevisitedCount(1L)
+			.totalReviewCount(1L)
+			.build();
+
+		List<StoreLocationRange> bookMarkList = Arrays.asList(storeLocationRange1, storeLocationRange2);
+		List<StoreLocationRange> locationRangeList = Arrays.asList(storeLocationRange3, storeLocationRange4);
+
+		StoreLocationRangeResponse storeLocationRangeResponse =
+			StoreLocationRangeResponse.of(bookMarkList, locationRangeList);
+
+		given(storeService.getRangeStores(eq(latitude1), eq(longitude1), eq(latitude2)
+			, eq(longitude2), eq(level), eq(java.util.Optional.ofNullable(type)), any()))
+			.willReturn(storeLocationRangeResponse);
+
+		// when
+		mockMvc.perform(
+				get("/api/v1/stores/location-range")
+					.contentType(MediaType.APPLICATION_JSON)
+					// .with(csrf())
+					.header("Authorization", "Bearer accessToken")
+					.param("latitude1", String.valueOf(latitude1))
+					.param("longitude1", String.valueOf(longitude1))
+					.param("latitude2", String.valueOf(latitude2))
+					.param("longitude2", String.valueOf(longitude2))
+					.param("level", String.valueOf(level))
+					.param("type", String.valueOf(type.getType())))
+			.andExpect(status().isOk())
+			.andDo(
+				restDocs.document(
+					requestHeaders(
+						headerWithName("Authorization").description("accessToken")
+					),
+					queryParameters(
+						parameterWithName("latitude1").description("첫번째 위도"),
+						parameterWithName("longitude1").description("두번째 경도"),
+						parameterWithName("latitude2").description("두번째 위도"),
+						parameterWithName("longitude2").description("두번째 경도"),
+						parameterWithName("level").description("확대/축소 레벨"),
+						parameterWithName("type").description("식당 카테고리 - optional").optional()
+					),
+					responseFields(
+						fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과코드"),
+						fieldWithPath("message").type(JsonFieldType.STRING).description("결과메시지"),
+						// bookMarkList
+						fieldWithPath("data.bookMarkList[]").type(JsonFieldType.ARRAY).description("북마크한 식당 목록"),
+						fieldWithPath("data.bookMarkList[].storeId").type(JsonFieldType.NUMBER)
+							.description("우리 DB상 음식점 ID"),
+						fieldWithPath("data.bookMarkList[].kakaoStoreId").type(JsonFieldType.NUMBER)
+							.description("카카오 DB상 음식점 ID"),
+						fieldWithPath("data.bookMarkList[].storeName").type(JsonFieldType.STRING).description("음식점 명"),
+						fieldWithPath("data.bookMarkList[].categoryId").type(JsonFieldType.NUMBER)
+							.description("음식점 카테고리 ID"),
+						fieldWithPath("data.bookMarkList[].categoryName").type(JsonFieldType.STRING)
+							.description("음식점 카테고리 명"),
+						fieldWithPath("data.bookMarkList[].categoryType").type(JsonFieldType.STRING)
+							.description("음식점 카테고리 타입"),
+						fieldWithPath("data.bookMarkList[].address").type(JsonFieldType.STRING).description("음식점 주소"),
+						fieldWithPath("data.bookMarkList[].longitude").type(JsonFieldType.NUMBER).description("음식점 위도"),
+						fieldWithPath("data.bookMarkList[].latitude").type(JsonFieldType.NUMBER).description("음식점 경도"),
+						fieldWithPath("data.bookMarkList[].totalRevisitedCount").type(JsonFieldType.NUMBER)
+							.description("재방문한 인원수 (N명 재방문)"),
+						fieldWithPath("data.bookMarkList[].totalReviewCount").type(JsonFieldType.NUMBER)
+							.description("총 리뷰 갯수"),
+						// locationStoreList
+						fieldWithPath("data.locationStoreList[]").type(JsonFieldType.ARRAY)
+							.description("요청한 위경도 내 식당 목록"),
+						fieldWithPath("data.locationStoreList[].storeId").type(JsonFieldType.NUMBER)
+							.description("우리 DB상 음식점 ID"),
+						fieldWithPath("data.locationStoreList[].kakaoStoreId").type(JsonFieldType.NUMBER)
+							.description("카카오 DB상 음식점 ID"),
+						fieldWithPath("data.locationStoreList[].storeName").type(JsonFieldType.STRING)
+							.description("음식점 명"),
+						fieldWithPath("data.locationStoreList[].categoryId").type(JsonFieldType.NUMBER)
+							.description("음식점 카테고리 ID"),
+						fieldWithPath("data.locationStoreList[].categoryName").type(JsonFieldType.STRING)
+							.description("음식점 카테고리 명"),
+						fieldWithPath("data.locationStoreList[].categoryType").type(JsonFieldType.STRING)
+							.description("음식점 카테고리 타입"),
+						fieldWithPath("data.locationStoreList[].address").type(JsonFieldType.STRING)
+							.description("음식점 주소"),
+						fieldWithPath("data.locationStoreList[].longitude").type(JsonFieldType.NUMBER)
+							.description("음식점 위도"),
+						fieldWithPath("data.locationStoreList[].latitude").type(JsonFieldType.NUMBER)
+							.description("음식점 경도"),
+						fieldWithPath("data.locationStoreList[].totalRevisitedCount").type(JsonFieldType.NUMBER)
+							.description("재방문한 인원수 (N명 재방문)"),
+						fieldWithPath("data.locationStoreList[].totalReviewCount").type(JsonFieldType.NUMBER)
+							.description("총 리뷰 갯수")
+					)
+				)
+			);
 	}
 
 }

--- a/server-api/src/test/java/com/depromeet/controller/StoreControllerTest.java
+++ b/server-api/src/test/java/com/depromeet/controller/StoreControllerTest.java
@@ -461,7 +461,15 @@ class StoreControllerTest extends RestDocsTestSupport {
 						parameterWithName("latitude2").description("두번째 위도"),
 						parameterWithName("longitude2").description("두번째 경도"),
 						parameterWithName("level").description("확대/축소 레벨"),
-						parameterWithName("type").description("식당 카테고리 - optional").optional()
+						parameterWithName("type").description("식당 카테고리(optional) - "
+								+ "\nKOREAN(한식)"
+								+ "\nCHINESE(중식)"
+								+ "\nJAPANESE(일식)"
+								+ "\nWESTERN(양식)"
+								+ "\nCAFE(카페,디저트)"
+								+ "\nBARS(술집)"
+								+ "\nSCHOOLFOOD(분식)")
+							.optional()
 					),
 					responseFields(
 						fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과코드"),
@@ -478,7 +486,15 @@ class StoreControllerTest extends RestDocsTestSupport {
 						fieldWithPath("data.bookMarkList[].categoryName").type(JsonFieldType.STRING)
 							.description("음식점 카테고리 명"),
 						fieldWithPath("data.bookMarkList[].categoryType").type(JsonFieldType.STRING)
-							.description("음식점 카테고리 타입"),
+							.description("음식점 카테고리 타입"
+								+ "\nKOREAN(한식)"
+								+ "\nCHINESE(중식)"
+								+ "\nJAPANESE(일식)"
+								+ "\nWESTERN(양식)"
+								+ "\nCAFE(카페,디저트)"
+								+ "\nBARS(술집)"
+								+ "\nSCHOOLFOOD(분식)"
+								+ "\nETC(기타)"),
 						fieldWithPath("data.bookMarkList[].address").type(JsonFieldType.STRING).description("음식점 주소"),
 						fieldWithPath("data.bookMarkList[].longitude").type(JsonFieldType.NUMBER).description("음식점 위도"),
 						fieldWithPath("data.bookMarkList[].latitude").type(JsonFieldType.NUMBER).description("음식점 경도"),
@@ -500,7 +516,15 @@ class StoreControllerTest extends RestDocsTestSupport {
 						fieldWithPath("data.locationStoreList[].categoryName").type(JsonFieldType.STRING)
 							.description("음식점 카테고리 명"),
 						fieldWithPath("data.locationStoreList[].categoryType").type(JsonFieldType.STRING)
-							.description("음식점 카테고리 타입"),
+							.description("음식점 카테고리 타입"
+								+ "\nKOREAN(한식)"
+								+ "\nCHINESE(중식)"
+								+ "\nJAPANESE(일식)"
+								+ "\nWESTERN(양식)"
+								+ "\nCAFE(카페,디저트)"
+								+ "\nBARS(술집)"
+								+ "\nSCHOOLFOOD(분식)"
+								+ "\nETC(기타)"),
 						fieldWithPath("data.locationStoreList[].address").type(JsonFieldType.STRING)
 							.description("음식점 주소"),
 						fieldWithPath("data.locationStoreList[].longitude").type(JsonFieldType.NUMBER)

--- a/server-domain/src/main/java/com/depromeet/domains/category/entity/Category.java
+++ b/server-domain/src/main/java/com/depromeet/domains/category/entity/Category.java
@@ -1,9 +1,12 @@
 package com.depromeet.domains.category.entity;
 
 import com.depromeet.domains.common.entity.BaseTimeEntity;
+import com.depromeet.enums.CategoryType;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -22,4 +25,8 @@ public class Category extends BaseTimeEntity {
 
 	@Column(nullable = false)
 	private String categoryName;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private CategoryType categoryType;
 }

--- a/server-domain/src/main/java/com/depromeet/domains/store/repository/StoreQueryRepository.java
+++ b/server-domain/src/main/java/com/depromeet/domains/store/repository/StoreQueryRepository.java
@@ -1,0 +1,18 @@
+package com.depromeet.domains.store.repository;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+
+@Repository
+public class StoreQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	public StoreQueryRepository(EntityManager entityManager) {
+		this.queryFactory = new JPAQueryFactory(entityManager);
+	}
+
+}

--- a/server-domain/src/main/java/com/depromeet/domains/store/repository/StoreRepository.java
+++ b/server-domain/src/main/java/com/depromeet/domains/store/repository/StoreRepository.java
@@ -1,66 +1,44 @@
 package com.depromeet.domains.store.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.depromeet.domains.store.entity.Store;
+import com.depromeet.enums.CategoryType;
 
 @Repository
 public interface StoreRepository extends JpaRepository<Store, Long> {
 
-	/**
-	 * 특정 위, 경도 범위 안에 있는 식당 정보 + 해당 user의 북마크 여부
-	 */
-	// @Query(value = ""
-	// 	+ "SELECT A.store_id "
-	// 	+ "		, A.store_name "
-	// 	+ "		, A.latitude "
-	// 	+ "		, A.longitude "
-	// 	+ "		, if(sum(isBookmark) = 1, true, false) AS isBookmarkedStore "
-	// 	+ "FROM ( "
-	// 	+ " 	SELECT s.store_id "
-	// 	+ "				, s.store_name "
-	// 	+ "			, IF(b.is_deleted = 0 AND b.user_id = :userId, 1, 0) AS isBookmark "
-	// 	+ "			, b.user_id "
-	// 	+ "			, s.latitude "
-	// 	+ "			, s.longitude "
-	// 	+ "		FROM Store s "
-	// 	+ "		LEFT JOIN Bookmark b ON s.store_id = b.store_id "
-	// 	+ "		WHERE s.latitude <= :maxLatitude "
-	// 	+ "		  AND s.latitude >= :minLatitude "
-	// 	+ "		  AND s.longitude <= :maxLongitude "
-	// 	+ "		  AND s.longitude >= :minLongitude "
-	// 	+ "		) A "
-	// 	+ "GROUP BY A.store_id ", nativeQuery = true)
-	// List<Object[]> findByLocationRangesWithIsBookmark(@Param("maxLatitude") Double maxLatitude
-	// 	, @Param("minLatitude") Double minLatitude
-	// 	, @Param("maxLongitude") Double maxLongitude
-	// 	, @Param("minLongitude") Double minLongitude
-	// 	, @Param("userId") Long userId
-	// );
+	@Query("SELECT s "
+		+ "      FROM Store s "
+		+ "      LEFT JOIN FETCH s.storeMeta sm "
+		+ "  WHERE s.location.latitude <= :maxLatitude "
+		+ " 	  AND s.location.latitude >= :minLatitude "
+		+ " 	  AND s.location.longitude <= :maxLongitude "
+		+ " 	  AND s.location.longitude >= :minLongitude "
+		+ " 	  AND (s.category.categoryType = :categoryType or :categoryType is null) "
+		+ " 	  AND s.storeId NOT IN (:storeIdList) "
+		+ "    ORDER BY sm.totalReviewCount ")
+	List<Store> findByLocationRangesWithCategory(
+		@Param("maxLatitude") double maxLatitude,
+		@Param("minLatitude") double minLatitude,
+		@Param("maxLongitude") double maxLongitude,
+		@Param("minLongitude") double minLongitude,
+		@Param("categoryType") CategoryType categoryType,
+		@Param("storeIdList") List<Long> storeIdList);
 
-	/**
-	 * 각 식당들의 재방문한 사람들의 수
-	 */
-	// @Query(value = ""
-	// 	+ "SELECT C.store_id, C.store_name, SUM(C.isMoreThanRevisit) AS numberOfRevisitedUser "
-	// 	+ "FROM ( "
-	// 	+ "		SELECT A.store_id, B.store_name, IF(B.review_cnt >= 2, 1, 0) AS isMoreThanRevisit "
-	// 	+ "		FROM Store A "
-	// 	+ "		INNER JOIN ( "
-	// 	+ "					SELECT s.store_id, s.store_name, r.user_id, COUNT(r.review_id) AS review_cnt "
-	// 	+ "					FROM Store s "
-	// 	+ "					LEFT JOIN Review r ON s.store_id = r.store_id "
-	// 	+ "					WHERE r.is_deleted = 0 "
-	// 	+ "						AND s.store_id IN :storeIdList "
-	// 	+ " 					GROUP BY s.store_id, r.user_id "
-	// 	+ "					) B ON A.store_id = B.store_id "
-	// 	+ "		) C "
-	// 	+ "GROUP BY C.store_id "
-	// 	+ "", nativeQuery = true)
-	// List<Object[]> findByStoresWithNumberOfRevisitedUser(@Param("storeIdList") List<Long> storeIdList);
+	@Query(" SELECT s "
+		+ "      FROM Bookmark bm "
+		+ "      LEFT JOIN bm.store s "
+		+ "    WHERE bm.user.userId = :userId ")
+	List<Store> findByUsersBookMarkList(@Param("userId") Long userId);
 
 	Boolean existsByStoreNameAndAddress(String storeName, String address);
 
 	Store findByKakaoStoreId(Long kakaoStoreId);
+
 }

--- a/server-domain/src/main/java/com/depromeet/enums/CategoryType.java
+++ b/server-domain/src/main/java/com/depromeet/enums/CategoryType.java
@@ -1,0 +1,43 @@
+package com.depromeet.enums;
+
+import java.util.Arrays;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum CategoryType implements EnumType {
+
+	KOREAN("KOREAN", "한식"),
+	CHINESE("CHINESE", "중식"),
+	JAPANESE("JAPANESE", "일식"),
+	WESTERN("WESTERN", "양식"),
+	CAFE("CAFE", "카페,디저트"),
+	BARS("BARS", "술집"),
+	SCHOOLFOOD("SCHOOLFOOD", "분식"),
+	ETC("ETC", "기타");
+
+	private final String type;
+	private final String description;
+
+	public static CategoryType findByType(String categoryType) {
+		return Arrays.asList(CategoryType.values())
+			.stream()
+			.filter(t -> categoryType.equalsIgnoreCase(t.getType()))
+			.findFirst()
+			.orElse(CategoryType.ETC);
+	}
+
+	@Override
+	public String getName() {
+		return this.name();
+	}
+
+	@Override
+	public String getDescription() {
+		return this.description;
+	}
+
+	public String getType() {
+		return this.type;
+	}
+}

--- a/server-domain/src/main/java/com/depromeet/enums/ReviewType.java
+++ b/server-domain/src/main/java/com/depromeet/enums/ReviewType.java
@@ -3,17 +3,17 @@ package com.depromeet.enums;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
-public enum ReviewType implements EnumType{
-    REVISITED("재방문 리뷰"), PHOTO("사진 리뷰");
-    private final String description;
+public enum ReviewType implements EnumType {
+	REVISITED("재방문 리뷰"), PHOTO("사진 리뷰");
+	private final String description;
 
-    @Override
-    public String getName() {
-        return this.description;
-    }
+	@Override
+	public String getName() {
+		return this.name();
+	}
 
-    @Override
-    public String getDescription() {
-        return this.name();
-    }
+	@Override
+	public String getDescription() {
+		return this.description;
+	}
 }

--- a/server-domain/src/main/java/com/depromeet/enums/ViewLevel.java
+++ b/server-domain/src/main/java/com/depromeet/enums/ViewLevel.java
@@ -1,0 +1,32 @@
+package com.depromeet.enums;
+
+import java.util.Arrays;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ViewLevel {
+
+	ONE(1, 1.0),
+	TWO(2, 1.0),
+	THREE(3, 1.0),
+	FOUR(4, 0.9),
+	FIVE(5, 0.8),
+	SIX(6, 0.7),
+	SEVEN(7, 0.6),
+	EIGHT(8, 0.5),
+	NINE(9, 0.4),
+	ETC(-1, 0.0);
+
+	private final int level;
+	private final double ratio;
+
+	public static ViewLevel findByLevel(int level) {
+		return Arrays.stream(ViewLevel.values())
+			.filter(viewLevel -> viewLevel.getLevel() == level)
+			.findFirst()
+			.orElse(ViewLevel.ETC);
+	}
+}

--- a/server-domain/src/main/resources/data.sql
+++ b/server-domain/src/main/resources/data.sql
@@ -1,34 +1,34 @@
-INSERT INTO Category (categoryId, categoryName, createdAt)
-VALUES (1, '일식', NOW());
-INSERT INTO Category (categoryId, categoryName, createdAt)
-VALUES (2, '카페', NOW());
+INSERT INTO Category (categoryId, categoryName, categoryType, createdAt)
+VALUES (1, '한식', 'KOREAN', NOW()),
+       (2, '중식', 'CHINESE', NOW()),
+       (3, '일식', 'JAPANESE', NOW()),
+       (4, '양식', 'WESTERN', NOW()),
+       (5, '카페,디저트', 'CAFE', NOW()),
+       (6, '술집', 'BARS', NOW()),
+       (7, '분식', 'SCHOOLFOOD', NOW()),
+       (8, '기타', 'ETC', NOW());
 
 INSERT INTO User (socialType, nickName, userRole, socialId, level, myReviewCount, createdAt)
-VALUES ('KAKAO', '김철수', 'USER', 'kakao1234', 'LEVEL1', 0, NOW());
+VALUES ('KAKAO', '김철수', 'USER', 'kakao1234', 'LEVEL1', 0, NOW()),
+       ('KAKAO', '이영희', 'USER', 'KAKAO11', 'LEVEL2', 3, NOW()),
+       ('APPLE', '김동현', 'USER', 'kakao123411', 'LEVEL3', 11, NOW()),
+       ('APPLE', '김나다', 'USER', 'kakao12341111', 'LEVEL4', 21, NOW());
 
-INSERT INTO User (socialType, nickName, userRole, socialId, level, myReviewCount, createdAt)
-VALUES ('KAKAO', '이영희', 'USER', 'KAKAO11', 'LEVEL2', 3, NOW());
-
-INSERT INTO User (socialType, nickName, userRole, socialId, level, myReviewCount, createdAt)
-VALUES ('APPLE', '김동현', 'USER', 'kakao123411', 'LEVEL3', 11, NOW());
-
-INSERT INTO User (socialType, nickName, userRole, socialId, level, myReviewCount, createdAt)
-VALUES ('APPLE', '김나다', 'USER', 'kakao12341111', 'LEVEL4', 21, NOW());
-
-INSERT INTO StoreMeta (totalRevisitedCount, totalReviewCount, mostVisitedCount,totalRating, createdAt, updatedAt)
+INSERT INTO StoreMeta (totalRevisitedCount, totalReviewCount, mostVisitedCount, totalRating, createdAt, updatedAt)
 VALUES (5, 14, 3, 4.5, NOW(), NOW()),
        (0, 4, 0, 5.0, NOW(), NOW()),
        (2, 8, 2, 4.0, NOW(), NOW()),
-       (10, 50, 5, 3.5,NOW(), NOW()),
+       (10, 50, 5, 3.5, NOW(), NOW()),
        (1, 3, 2, 3.0, NOW(), NOW());
 -- Store 테이블에 데이터 삽입
-INSERT INTO Store (category_id, store_meta_id, storeName, latitude, longitude, address, thumbnailUrl, kakaoStoreId, createdAt, updatedAt)
-VALUES (1, 1, '맛집1', 37.3665, 123.9780, '서울특별시 중구 세종대로 110', 'thumbnail1.jpg', '234',NOW(), NOW()),
-       (2, 2, '카페2', 37.6651, 126.98955, '서울특별시 중구 청계천로 100', 'thumbnail2.jpg', '3342',NOW(), NOW()),
-       (1, 3, '맛집2', 43.5665, 130.9780, '서울특별시 관악구 봉천동 62-1', 'thumbnail3.jpg', '1234',NOW(), NOW()),
-       (2, 4, '카페2', 45.5651, 131.98955, '서울특별시 강남구 테헤란로 21-10', 'thumbnail4.jpg', '3497',NOW(), NOW()),
-       (1, 5, '티컵 스타필드 코엑스몰점', 37.5126847515106, 127.058938708812, '서울 강남구 삼성동 159', 'thumbnail1.jpg', '43234',NOW(), NOW());
-
+INSERT INTO Store (category_id, store_meta_id, storeName, latitude, longitude, address, thumbnailUrl, kakaoStoreId,
+                   createdAt, updatedAt)
+VALUES (1, 1, '맛집1', 37.3665, 123.9780, '서울특별시 중구 세종대로 110', 'thumbnail1.jpg', '234', NOW(), NOW()),
+       (2, 2, '카페2', 37.6651, 126.98955, '서울특별시 중구 청계천로 100', 'thumbnail2.jpg', '3342', NOW(), NOW()),
+       (1, 3, '맛집2', 43.5665, 130.9780, '서울특별시 관악구 봉천동 62-1', 'thumbnail3.jpg', '1234', NOW(), NOW()),
+       (2, 4, '카페2', 45.5651, 131.98955, '서울특별시 강남구 테헤란로 21-10', 'thumbnail4.jpg', '3497', NOW(), NOW()),
+       (1, 5, '티컵 스타필드 코엑스몰점', 37.5126847515106, 127.058938708812, '서울 강남구 삼성동 159', 'thumbnail1.jpg', '43234', NOW(),
+        NOW());
 
 
 INSERT INTO Review (store_id, user_id, rating, visitedAt, imageUrl, visitTimes, description, createdAt)
@@ -64,21 +64,14 @@ INSERT INTO Review (store_id, user_id, rating, visitedAt, imageUrl, visitTimes, 
 VALUES (1, 1, 5, '2022-01-01T12:00:00', 'http://example.com/image2.jpg', 1, '맛있었어요', '2022-01-01T11:00:00');
 
 INSERT INTO Bookmark (user_id, store_id, isDeleted, createdAt, updatedAt)
-VALUES (1, 1, 0, now(), now());
-INSERT INTO Bookmark (user_id, store_id, isDeleted, createdAt, updatedAt)
-VALUES (1, 2, 0, now(), now());
-INSERT INTO Bookmark (user_id, store_id, isDeleted, createdAt, updatedAt)
-VALUES (1, 3, 0, now(), now());
-INSERT INTO Bookmark (user_id, store_id, isDeleted, createdAt, updatedAt)
-VALUES (2, 1, 0, now(), now());
-INSERT INTO Bookmark (user_id, store_id, isDeleted, createdAt, updatedAt)
-VALUES (2, 2, 0, now(), now());
-INSERT INTO Bookmark (user_id, store_id, isDeleted, createdAt, updatedAt)
-VALUES (3, 3, 0, now(), now());
-INSERT INTO Bookmark (user_id, store_id, isDeleted, createdAt, updatedAt)
-VALUES (4, 3, 0, now(), now());
-INSERT INTO Bookmark (user_id, store_id, isDeleted, createdAt, updatedAt)
-VALUES (4, 4, 0, now(), now());
+VALUES (1, 1, 0, now(), now()),
+       (1, 2, 0, now(), now()),
+       (1, 3, 0, now(), now()),
+       (2, 1, 0, now(), now()),
+       (2, 2, 0, now(), now()),
+       (3, 3, 0, now(), now()),
+       (4, 3, 0, now(), now()),
+       (4, 4, 0, now(), now());
 
 INSERT INTO Review (store_id, user_id, rating, visitedAt, imageUrl, visitTimes, description, createdAt)
 VALUES (1, 1, 3, '2022-01-01T12:00:00', 'http://example.com/image3.jpg', 1, '맛있었어요', '2022-01-01T17:00:00');


### PR DESCRIPTION
### ✅ PR 타입 & 이슈번호
ex) 기능 추가 (#8)

### 📌 상세 내용
- 맵 api 수정(Get, /api/v1/stores/location-range)
- 파라미터 정의(2곳의 위경도, 카테고리 타입, 줌아웃 레벨)

### 🔥 궁금한점
- 로컬에서 docs 생성까지 확인완료. 
- 그런데 enum 정의를 잘 모르겠네요. 필환님 메뉴얼 봤는데도 궁금한 점이 있어 내일(1/20,토) 조금 여쭤보겠습니다!


