### PR TITLE
[Feature/#81] 사용자 리뷰 작성 가능 여부 체크 API 추가

### DIFF
--- a/server-api/src/main/java/com/depromeet/domains/store/controller/StoreController.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/controller/StoreController.java
@@ -74,6 +74,12 @@ public class StoreController {
 		return CustomResponseEntity.created(storeService.createStoreReview(user, reviewRequest));
 	}
 
+	@GetMapping("/stores/{storeId}/reviews/check-limit")
+	public CustomResponseEntity<Boolean> getUserDailyStoreReviewLimit(@AuthUser User user, @PathVariable Long storeId) {
+		boolean isAvailable = storeService.checkUserDailyStoreReviewLimit(user, storeId);
+		return CustomResponseEntity.success(isAvailable);
+	}
+
 	// 리뷰 삭제
 	@DeleteMapping("/reviews/{reviewId}")
     public CustomResponseEntity<Void> deleteStoreReview(@AuthUser User user,

--- a/server-api/src/main/java/com/depromeet/domains/store/controller/StoreController.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/controller/StoreController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import com.depromeet.annotation.AuthUser;
 import com.depromeet.common.exception.CustomResponseEntity;
 import com.depromeet.domains.store.dto.request.ReviewRequest;
+import com.depromeet.domains.store.dto.response.ReviewAddLimitResponse;
 import com.depromeet.domains.store.dto.response.ReviewAddResponse;
 import com.depromeet.domains.store.dto.response.StoreLocationRangeResponse;
 import com.depromeet.domains.store.dto.response.StorePreviewResponse;
@@ -75,9 +76,8 @@ public class StoreController {
 	}
 
 	@GetMapping("/stores/{storeId}/reviews/check-limit")
-	public CustomResponseEntity<Boolean> getUserDailyStoreReviewLimit(@AuthUser User user, @PathVariable Long storeId) {
-		boolean isAvailable = storeService.checkUserDailyStoreReviewLimit(user, storeId);
-		return CustomResponseEntity.success(isAvailable);
+	public CustomResponseEntity<ReviewAddLimitResponse> getUserDailyStoreReviewLimit(@AuthUser User user, @PathVariable Long storeId) {
+		return CustomResponseEntity.success(storeService.checkUserDailyStoreReviewLimit(user, storeId));
 	}
 
 	// 리뷰 삭제

--- a/server-api/src/main/java/com/depromeet/domains/store/dto/response/ReviewAddLimitResponse.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/dto/response/ReviewAddLimitResponse.java
@@ -1,0 +1,16 @@
+package com.depromeet.domains.store.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReviewAddLimitResponse {
+	private Boolean isAvailable;
+
+	public static ReviewAddLimitResponse of(boolean isAvailable) {
+		return ReviewAddLimitResponse.builder()
+			.isAvailable(isAvailable)
+			.build();
+	}
+}

--- a/server-api/src/main/java/com/depromeet/domains/store/service/StoreService.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/service/StoreService.java
@@ -23,6 +23,7 @@ import com.depromeet.domains.review.entity.Review;
 import com.depromeet.domains.review.repository.ReviewRepository;
 import com.depromeet.domains.store.dto.request.NewStoreRequest;
 import com.depromeet.domains.store.dto.request.ReviewRequest;
+import com.depromeet.domains.store.dto.response.ReviewAddLimitResponse;
 import com.depromeet.domains.store.dto.response.ReviewAddResponse;
 import com.depromeet.domains.store.dto.response.StoreLocationRangeResponse;
 import com.depromeet.domains.store.dto.response.StorePreviewResponse;
@@ -341,7 +342,7 @@ public class StoreService {
 		reviewRepository.delete(review);
 	}
 
-	public boolean checkUserDailyStoreReviewLimit(User user, Long storeId) {
+	public ReviewAddLimitResponse checkUserDailyStoreReviewLimit(User user, Long storeId) {
 		Store store = storeRepository.findById(storeId)
 			.orElseThrow(() -> new CustomException(Result.NOT_FOUND_STORE));
 
@@ -349,6 +350,6 @@ public class StoreService {
 		LocalDateTime endOfDay = LocalDate.now().atTime(23, 59, 59);
 
 		int reviewCount = reviewRepository.countStoreReviewByUserForDay(user, store, startOfDay, endOfDay);
-		return reviewCount < 3;
+		return ReviewAddLimitResponse.of(reviewCount < 3);
 	}
 }

--- a/server-api/src/main/java/com/depromeet/domains/store/service/StoreService.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/service/StoreService.java
@@ -1,5 +1,7 @@
 package com.depromeet.domains.store.service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -337,5 +339,16 @@ public class StoreService {
 			}
 		}
 		reviewRepository.delete(review);
+	}
+
+	public boolean checkUserDailyStoreReviewLimit(User user, Long storeId) {
+		Store store = storeRepository.findById(storeId)
+			.orElseThrow(() -> new CustomException(Result.NOT_FOUND_STORE));
+
+		LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+		LocalDateTime endOfDay = LocalDate.now().atTime(23, 59, 59);
+
+		int reviewCount = reviewRepository.countStoreReviewByUserForDay(user, store, startOfDay, endOfDay);
+		return reviewCount < 3;
 	}
 }

--- a/server-api/src/test/java/com/depromeet/controller/StoreControllerTest.java
+++ b/server-api/src/test/java/com/depromeet/controller/StoreControllerTest.java
@@ -28,6 +28,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import com.depromeet.document.RestDocsTestSupport;
 import com.depromeet.domains.store.dto.request.NewStoreRequest;
 import com.depromeet.domains.store.dto.request.ReviewRequest;
+import com.depromeet.domains.store.dto.response.ReviewAddLimitResponse;
 import com.depromeet.domains.store.dto.response.ReviewAddResponse;
 import com.depromeet.domains.store.dto.response.StoreLocationRangeResponse;
 import com.depromeet.domains.store.dto.response.StoreLocationRangeResponse.StoreLocationRange;
@@ -547,9 +548,7 @@ class StoreControllerTest extends RestDocsTestSupport {
 	@Test
 	void getUserDailyStoreReviewLimit() throws Exception {
 		// given
-
-
-		given(storeService.checkUserDailyStoreReviewLimit(any(),eq(1L))).willReturn(true);
+		given(storeService.checkUserDailyStoreReviewLimit(any(),eq(1L))).willReturn(ReviewAddLimitResponse.of(false));
 
 		// when
 		mockMvc.perform(
@@ -569,7 +568,8 @@ class StoreControllerTest extends RestDocsTestSupport {
 					responseFields(
 						fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과코드"),
 						fieldWithPath("message").type(JsonFieldType.STRING).description("결과메시지"),
-						fieldWithPath("data").type(JsonFieldType.BOOLEAN).description("리뷰 작성 가능 여부 반환")
+						fieldWithPath("data").type(JsonFieldType.OBJECT).description("리뷰 작성 가능 여부 반환"),
+						fieldWithPath("data.isAvailable").type(JsonFieldType.BOOLEAN).description("리뷰 작성 가능 여부 반환 (작성가능 : true, 작성불가 : false)")
 					)
 				)
 			);

--- a/server-api/src/test/java/com/depromeet/controller/StoreControllerTest.java
+++ b/server-api/src/test/java/com/depromeet/controller/StoreControllerTest.java
@@ -544,4 +544,35 @@ class StoreControllerTest extends RestDocsTestSupport {
 			);
 	}
 
+	@Test
+	void getUserDailyStoreReviewLimit() throws Exception {
+		// given
+
+
+		given(storeService.checkUserDailyStoreReviewLimit(any(),eq(1L))).willReturn(true);
+
+		// when
+		mockMvc.perform(
+				get("/api/v1/stores/{storeId}/reviews/check-limit", 1L)
+					.with(csrf())
+					.contentType(MediaType.APPLICATION_JSON)
+					.header("Authorization", "Bearer accessToken"))
+			.andExpect(status().isOk())
+			.andDo(
+				restDocs.document(
+					pathParameters(
+						parameterWithName("storeId").description("음식점 ID")
+					),
+					requestHeaders(
+						headerWithName("Authorization").description("accessToken")
+					),
+					responseFields(
+						fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과코드"),
+						fieldWithPath("message").type(JsonFieldType.STRING).description("결과메시지"),
+						fieldWithPath("data").type(JsonFieldType.BOOLEAN).description("리뷰 작성 가능 여부 반환")
+					)
+				)
+			);
+	}
+
 }

--- a/server-domain/src/main/java/com/depromeet/domains/review/repository/ReviewRepository.java
+++ b/server-domain/src/main/java/com/depromeet/domains/review/repository/ReviewRepository.java
@@ -1,8 +1,7 @@
 package com.depromeet.domains.review.repository;
 
-import com.depromeet.domains.review.entity.Review;
-import com.depromeet.domains.store.entity.Store;
-import com.depromeet.domains.user.entity.User;
+import java.time.LocalDateTime;
+import java.util.List;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -10,7 +9,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
+import com.depromeet.domains.review.entity.Review;
+import com.depromeet.domains.store.entity.Store;
+import com.depromeet.domains.user.entity.User;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
@@ -45,5 +46,10 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     Long countByVisitTimes(Long visitTimes);
 
     Slice<Review> findByStore(Store store, Pageable pageable);
+
+    @Query("SELECT COUNT(r) FROM Review r WHERE r.store = :store AND r.user = :user AND r.createdAt BETWEEN :startOfDay AND :endOfDay")
+    int countStoreReviewByUserForDay(@Param("user") User user, @Param("store") Store store,
+        @Param("startOfDay") LocalDateTime startOfDay,
+        @Param("endOfDay") LocalDateTime endOfDay);
 
 }


### PR DESCRIPTION
### ✅ PR 타입 & 이슈번호
기능 추가 (#81)

### 📌 상세 내용
- 리뷰 작성 일자 기준 3번만 작성 가능

### 🔥 궁금한점
현재 이 API로 프론트에서 버튼 자체를 disable 시키겠지만, 이렇게 체크하는 로직을 리뷰 작성 API에도 넣어야할까요?
아니면 굳이 싶은가요?


