### PR TITLE
[Feature/#98] 카카오 로그인 security oauth2 -> rest api 방식으로 변경

### DIFF
--- a/server-api/src/docs/asciidoc/index.adoc
+++ b/server-api/src/docs/asciidoc/index.adoc
@@ -43,44 +43,11 @@ operation::common-doc-controller-test/error-sample[snippets='http-response,respo
 == Auth API
 [[login]]
 === 1. 로그인
-* "accessToken", "refreshToken"으로 쿠키에 토큰 담아 반환
 
-Request
-[source,http]
-----
-GET /oauth2/authorization/{provider}?env=local HTTP/1.1
-Host: localhost:8080
-Content-Type: application/json;charset=UTF-8
-----
-Path Parameter
-[cols="1,2,3", options="header"]
-|===
-| Parameter
-| Description
-| Example Values
-
-| provider
-| 소셜로그인 종류
-| apple, kakao
-
-|===
-
-Query Parameter
-[cols="1,2,3", options="header"]
-|===
-| Parameter
-| Description
-| Example Values
-
-| env
-| 프론트 요청 환경
-| local, dev (쿼리 스트링 없이 보낸 경우 dev로 리다이렉트 됩니다)
-
-|===
+operation::auth-controller-test/social-login[snippets='curl-request,http-request,query-parameters,http-response']
 
 [[signup]]
 === 2. 약관동의 후 회원가입
-* 리다이렉트 쿼리스트링으로 "accessToken", "refreshToken" 반환
 
 operation::auth-controller-test/signup[snippets='curl-request,http-request,request-headers,http-response']
 
@@ -92,7 +59,6 @@ operation::auth-controller-test/refresh-token[snippets='curl-request,http-reques
 
 [[logout]]
 === 4. 로그아웃
-* 쿠키를 삭제시킨 후 반환합니다
 
 operation::auth-controller-test/logout[snippets='curl-request,http-request,http-response']
 

--- a/server-api/src/main/java/com/depromeet/auth/controller/AuthController.java
+++ b/server-api/src/main/java/com/depromeet/auth/controller/AuthController.java
@@ -47,7 +47,7 @@ public class AuthController {
 		@RequestHeader("Authorization-refresh") String refreshToken
 	) {
 		TokenResponse tokenResponse = authService.reissueToken(refreshToken);
-		return CustomResponseEntity.success(new TokenResponse(tokenResponse.getAccessToken()));
+		return CustomResponseEntity.success(tokenResponse);
 	}
 
 	@PostMapping("/signup")
@@ -72,6 +72,6 @@ public class AuthController {
 		String accessToken = jwtService.createAccessToken(userId);
 		String refreshToken = jwtService.createRefreshToken(userId);
 
-		return CustomResponseEntity.success(new TokenResponse(accessToken, refreshToken));
+		return CustomResponseEntity.success(TokenResponse.builder().accessToken(accessToken).refreshToken(refreshToken).build());
 	}
 }

--- a/server-api/src/main/java/com/depromeet/auth/controller/AuthController.java
+++ b/server-api/src/main/java/com/depromeet/auth/controller/AuthController.java
@@ -3,14 +3,15 @@ package com.depromeet.auth.controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.depromeet.annotation.AuthUser;
 import com.depromeet.auth.dto.TokenResponse;
 import com.depromeet.auth.jwt.JwtService;
 import com.depromeet.auth.service.AuthService;
-import com.depromeet.auth.service.CookieService;
 import com.depromeet.common.exception.CustomResponseEntity;
 import com.depromeet.domains.user.entity.User;
 
@@ -24,20 +25,28 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping(value = "/api/v1/auth")
 public class AuthController {
 	private final AuthService authService;
-	private final CookieService cookieService;
 	private final JwtService jwtService;
+
+	@GetMapping("/login")
+	public CustomResponseEntity<TokenResponse> loginWithKakao(
+		@RequestParam String provider,
+		@RequestParam String code
+	) {
+		// TODO: provider에 따라서 로그인 처리
+		if ("kakao".equals(provider)) {
+			return CustomResponseEntity.success(authService.kakaoLogin(code));
+		}
+		return CustomResponseEntity.success(authService.kakaoLogin(code));
+	}
 
 	/**
 	 * Refresh Token으로 사용자 Access Token 갱신 요청
 	 */
 	@PostMapping("/token/reissue")
 	public CustomResponseEntity<TokenResponse> refreshToken(
-		HttpServletRequest request, HttpServletResponse response
-	) throws IllegalAccessException {
-		TokenResponse tokenResponse = authService.reissueToken(request);
-		// 응답 헤더에 쿠키 추가
-		response.addCookie(cookieService.createRefreshTokenCookie(tokenResponse.getRefreshToken()));
-
+		@RequestHeader("Authorization-refresh") String refreshToken
+	) {
+		TokenResponse tokenResponse = authService.reissueToken(refreshToken);
 		return CustomResponseEntity.success(new TokenResponse(tokenResponse.getAccessToken()));
 	}
 
@@ -49,8 +58,8 @@ public class AuthController {
 	}
 
 	@PostMapping("/logout")
-	public void logout(HttpServletRequest request, HttpServletResponse response) {
-		authService.logout(request, response);
+	public void logout(@AuthUser User user, HttpServletRequest request, HttpServletResponse response) {
+		authService.logout(user, request, response);
 	}
 
 	/**
@@ -62,9 +71,6 @@ public class AuthController {
 		HttpServletResponse response) {
 		String accessToken = jwtService.createAccessToken(userId);
 		String refreshToken = jwtService.createRefreshToken(userId);
-
-		response.addCookie(cookieService.createAccessTokenCookie(accessToken));
-		response.addCookie(cookieService.createRefreshTokenCookie(refreshToken));
 
 		return CustomResponseEntity.success(new TokenResponse(accessToken, refreshToken));
 	}

--- a/server-api/src/main/java/com/depromeet/auth/controller/AuthController.java
+++ b/server-api/src/main/java/com/depromeet/auth/controller/AuthController.java
@@ -28,7 +28,7 @@ public class AuthController {
 	private final JwtService jwtService;
 
 	@GetMapping("/login")
-	public CustomResponseEntity<TokenResponse> loginWithKakao(
+	public CustomResponseEntity<TokenResponse> socialLogin(
 		@RequestParam String provider,
 		@RequestParam String code
 	) {

--- a/server-api/src/main/java/com/depromeet/auth/controller/KakaoTokenClient.java
+++ b/server-api/src/main/java/com/depromeet/auth/controller/KakaoTokenClient.java
@@ -1,0 +1,18 @@
+package com.depromeet.auth.controller;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.depromeet.auth.dto.KakaoTokenResponse;
+
+@FeignClient(name = "KakaoTokenClient", url = "https://kauth.kakao.com")
+public interface KakaoTokenClient {
+	@PostMapping("/oauth/token")
+	KakaoTokenResponse getToken(@RequestParam("grant_type") String grantType,
+		@RequestParam("client_id") String clientId,
+		@RequestParam("redirect_uri") String redirectUri,
+		@RequestParam("code") String code,
+		@RequestParam("client_secret") String clientSecret);
+
+}

--- a/server-api/src/main/java/com/depromeet/auth/controller/KakaoUserClient.java
+++ b/server-api/src/main/java/com/depromeet/auth/controller/KakaoUserClient.java
@@ -1,0 +1,14 @@
+package com.depromeet.auth.controller;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import com.depromeet.auth.dto.KakaoUserInfo;
+
+@FeignClient(name = "kakaoUserClient", url = "https://kapi.kakao.com")
+public interface KakaoUserClient {
+	@GetMapping("/v2/user/me")
+	KakaoUserInfo getUserInfo(@RequestHeader("Authorization") String token);
+}
+

--- a/server-api/src/main/java/com/depromeet/auth/dto/KakaoTokenResponse.java
+++ b/server-api/src/main/java/com/depromeet/auth/dto/KakaoTokenResponse.java
@@ -1,0 +1,13 @@
+package com.depromeet.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoTokenResponse {
+	private String token_type;
+	private String access_token;
+	private Integer expires_in;
+	private String refresh_token;
+	private String refresh_token_expires_in;
+	private String scope;
+}

--- a/server-api/src/main/java/com/depromeet/auth/dto/KakaoUserInfo.java
+++ b/server-api/src/main/java/com/depromeet/auth/dto/KakaoUserInfo.java
@@ -1,0 +1,9 @@
+package com.depromeet.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoUserInfo {
+	private String id;
+	private String connected_at;
+}

--- a/server-api/src/main/java/com/depromeet/auth/dto/TokenResponse.java
+++ b/server-api/src/main/java/com/depromeet/auth/dto/TokenResponse.java
@@ -1,20 +1,14 @@
 package com.depromeet.auth.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class TokenResponse {
 	String accessToken;
 	String refreshToken;
-
-	public TokenResponse(String accessToken) {
-		this.accessToken = accessToken;
-	}
-
-	public TokenResponse(String accessToken, String refreshToken) {
-		this.accessToken = accessToken;
-		this.refreshToken = refreshToken;
-	}
+	Boolean isFirst;
 }

--- a/server-api/src/main/java/com/depromeet/auth/service/AuthService.java
+++ b/server-api/src/main/java/com/depromeet/auth/service/AuthService.java
@@ -2,17 +2,23 @@ package com.depromeet.auth.service;
 
 import java.security.SecureRandom;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.depromeet.auth.controller.KakaoTokenClient;
+import com.depromeet.auth.controller.KakaoUserClient;
+import com.depromeet.auth.dto.KakaoTokenResponse;
+import com.depromeet.auth.dto.KakaoUserInfo;
 import com.depromeet.auth.dto.TokenResponse;
 import com.depromeet.auth.jwt.JwtService;
 import com.depromeet.common.exception.CustomException;
 import com.depromeet.common.exception.Result;
 import com.depromeet.domains.user.entity.User;
 import com.depromeet.domains.user.repository.UserRepository;
+import com.depromeet.enums.Role;
+import com.depromeet.enums.SocialType;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -22,14 +28,42 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @Slf4j
 public class AuthService {
+
+	private static final String AUTHORIZATION_TYPE = "Bearer ";
+	private static final String AUTHORIZATION_CODE = "authorization_code";
+	private static final String GUEST_PREFIX = "게스트";
+
 	private final JwtService jwtService;
 	private final RedisService redisService;
-	private final CookieService cookieService;
 	private final UserRepository userRepository;
+	private final KakaoTokenClient kakaoTokenClient;
+	private final KakaoUserClient kakaoUserClient;
 
-	public TokenResponse reissueToken(HttpServletRequest request) {
-		Cookie cookie = cookieService.getCookie(request, "refreshToken").orElseThrow(() -> new CustomException(Result.NOT_FOUND_COOKIE));
-		String refreshToken = cookie.getValue();
+	@Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+	private String kakaoClientId;
+	@Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+	private String kakaoClientSecret;
+	@Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+	private String kakaoRedirectUrl;
+
+	public TokenResponse kakaoLogin(String code) {
+		// 액세스 토큰 요청
+		KakaoTokenResponse tokenResponse = kakaoTokenClient.getToken(AUTHORIZATION_CODE, kakaoClientId, kakaoRedirectUrl, code,
+			kakaoClientSecret);
+		// 사용자 정보 요청
+		KakaoUserInfo userResponse = kakaoUserClient.getUserInfo(AUTHORIZATION_TYPE + tokenResponse.getAccess_token());
+		// 사용자 정보로 회원가입 및 로그인
+		User user = userRepository.findBySocialTypeAndSocialId(SocialType.KAKAO, userResponse.getId())
+			.orElseGet(() -> createUser(userResponse));
+		//토큰 발급
+		String accessToken = jwtService.createAccessToken(user.getUserId());
+		String refreshToken = jwtService.createRefreshToken(user.getUserId());
+
+		return new TokenResponse(accessToken, refreshToken);
+	}
+
+
+	public TokenResponse reissueToken(String refreshToken) {
 
 		// Refresh Token 검증
 		if (!jwtService.isValidToken(refreshToken)) {
@@ -58,35 +92,16 @@ public class AuthService {
 	}
 
 	@Transactional
-	public void logout(HttpServletRequest request, HttpServletResponse response) {
-		// 1. 엑세스 토큰에서 사용자 ID 추출
+	public void logout(User user, HttpServletRequest request, HttpServletResponse response) {
+		// 엑세스 토큰에서 사용자 ID 추출
 		String accessToken = jwtService.resolveToken(request);
-		Long userId = jwtService.getUserIdFromToken(accessToken);
-
-		// 2. 리프레시 토큰 가져오기
-		Cookie cookie = cookieService.getCookie(request, "refreshToken")
-			.orElseThrow(() -> new CustomException(Result.NOT_FOUND_COOKIE));
-		String refreshToken = cookie.getValue();
-
-		// 3. Redis에 저장된 리프레시 토큰과 비교
-		String savedRefreshToken = redisService.getValues(String.valueOf(userId));
-		log.info("savedRefreshToken : " + savedRefreshToken);
-		log.info("headerRefreshToken : " + refreshToken);
-
-		if (savedRefreshToken == null || !savedRefreshToken.equals(refreshToken)) {
-			log.info("저장된 리프레쉬토큰이 없거나, 다른 토큰이 일치하지 않는 경우");
-			throw new CustomException(Result.TOKEN_INVALID);
-		}
 
 		// redis에서 삭제
-		redisService.deleteValues(String.valueOf(userId));
+		redisService.deleteValues(String.valueOf(user.getUserId()));
 
 		// redis에 블랙리스트 등록
 		Long leftAccessTokenTTlSecond = jwtService.getLeftAccessTokenTTLSecond(accessToken);
 		redisService.setValues(accessToken, "logout", leftAccessTokenTTlSecond);
-
-		cookieService.deleteAccessTokenCookie(response);
-		cookieService.deleteRefreshTokenCookie(response);
 	}
 
 	@Transactional
@@ -120,5 +135,15 @@ public class AuthService {
 			sb.append(allowedChars.charAt(randomIndex));
 		}
 		return prefix + sb;
+	}
+
+	private User createUser(KakaoUserInfo userInfo) {
+		User newUser = User.builder()
+			.socialType(SocialType.KAKAO)
+			.socialId(userInfo.getId())
+			.nickName(GUEST_PREFIX + userInfo.getId())
+			.userRole(Role.GUEST)
+			.build();
+		return userRepository.save(newUser);
 	}
 }

--- a/server-api/src/main/java/com/depromeet/auth/service/AuthService.java
+++ b/server-api/src/main/java/com/depromeet/auth/service/AuthService.java
@@ -55,11 +55,13 @@ public class AuthService {
 		// 사용자 정보로 회원가입 및 로그인
 		User user = userRepository.findBySocialTypeAndSocialId(SocialType.KAKAO, userResponse.getId())
 			.orElseGet(() -> createUser(userResponse));
+
+		boolean isFirst = user.getUserRole().equals(Role.GUEST);
 		//토큰 발급
 		String accessToken = jwtService.createAccessToken(user.getUserId());
 		String refreshToken = jwtService.createRefreshToken(user.getUserId());
 
-		return new TokenResponse(accessToken, refreshToken);
+		return TokenResponse.builder().accessToken(accessToken).refreshToken(refreshToken).isFirst(isFirst).build();
 	}
 
 
@@ -88,7 +90,7 @@ public class AuthService {
 		String newAccessToken = jwtService.createAccessToken(user.getUserId());
 		String newRefreshToken = jwtService.createRefreshToken(user.getUserId());
 
-		return new TokenResponse(newAccessToken, newRefreshToken);
+		return TokenResponse.builder().accessToken(newAccessToken).refreshToken(newRefreshToken).build();
 	}
 
 	@Transactional

--- a/server-api/src/main/java/com/depromeet/domains/user/service/UserService.java
+++ b/server-api/src/main/java/com/depromeet/domains/user/service/UserService.java
@@ -3,8 +3,6 @@ package com.depromeet.domains.user.service;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import com.depromeet.auth.service.CookieService;
 import com.depromeet.auth.service.RedisService;
 import com.depromeet.common.exception.CustomException;
 import com.depromeet.common.exception.Result;
@@ -30,7 +28,6 @@ import java.util.stream.Collectors;
 public class UserService {
 	private final RedisService redisService;
 	private final UserRepository userRepository;
-	private final CookieService cookieService;
 	private final BookmarkRepository bookmarkRepository;
 	private final ReviewRepository reviewRepository;
 
@@ -121,8 +118,5 @@ public class UserService {
 	public void deleteUser(User user, HttpServletResponse response) {
 		userRepository.deleteById(user.getUserId());
 		redisService.deleteValues(String.valueOf(user.getUserId()));
-
-		cookieService.deleteAccessTokenCookie(response);
-		cookieService.deleteRefreshTokenCookie(response);
 	}
 }

--- a/server-common/src/main/java/com/depromeet/common/exception/Result.java
+++ b/server-common/src/main/java/com/depromeet/common/exception/Result.java
@@ -20,7 +20,7 @@ public enum Result {
     DUPLICATED_NICKNAME(400, "이미 존재하는 닉네임입니다."),
     DUPLICATED_STORE(400, "이미 존재하는 가게입니다."),
     NOT_FOUND_COOKIE(401, "존재하지 않는 쿠키"),
-    NOT_FOUND_USER(404, "사용자를 찾을 수 없습니다."),
+    NOT_FOUND_USER(401, "사용자를 찾을 수 없습니다."),
     NOT_FOUND_BOOKMARK(404, "북마크를 찾을 수 없습니다."),
     NOT_FOUND_STORE(404, "가게를 찾을 수 없습니다."),
     NOT_FOUND_CATEGORY(404, "카테고리를 찾을 수 없습니다." ),


### PR DESCRIPTION
### ✅ PR 타입 & 이슈번호
기능 수정 (#8)

### 📌 상세 내용
- kakao feign client 추가
- 기존 쿠키 발급 로직 삭제

### 🔥 궁금한점



