### PR TITLE
Feature/#107 viewLevel 하한값 정의와 로직 수정, 조회기준 변경(리뷰순 -> 재방문자수)

### DIFF
--- a/server-api/src/main/java/com/depromeet/domains/store/service/StoreService.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/service/StoreService.java
@@ -141,30 +141,30 @@ public class StoreService {
 		return storeReviewResponse;
 	}
 
-
 	private Slice<StoreReviewResponse> getStoreReviewResponses(User user, Slice<Review> reviews, Store store) {
 		List<StoreReviewResponse> storeReviewResponseList = reviews.getContent().stream()
-				.map(review -> {
-					Integer maxVisitTimes = reviewRepository.maxVisitTimes(store, review.getUser());
-					// 현재 사용자가 리뷰 작성자와 동일한지 확인
-					Boolean isMine = review.getUser().getUserId().equals(user.getUserId()); // 사용자 비교 로직 수정
-					String imageUrl = review.getImageUrl() != null ? review.getImageUrl() : "";
-					// 필요한 정보를 포함하여 StoreReviewResponse 객체 생성
-					return StoreReviewResponse.of(
-							review.getUser().getUserId(),
-							review.getReviewId(),
-							review.getUser().getNickName(),
-							review.getRating(),
-							imageUrl,
-							maxVisitTimes,
-							review.getVisitedAt(),
-							review.getDescription(),
-							isMine
-					);
-				})
-				.collect(Collectors.toList());
+			.map(review -> {
+				Integer maxVisitTimes = reviewRepository.maxVisitTimes(store, review.getUser());
+				// 현재 사용자가 리뷰 작성자와 동일한지 확인
+				Boolean isMine = review.getUser().getUserId().equals(user.getUserId()); // 사용자 비교 로직 수정
+				String imageUrl = review.getImageUrl() != null ? review.getImageUrl() : "";
+				// 필요한 정보를 포함하여 StoreReviewResponse 객체 생성
+				return StoreReviewResponse.of(
+					review.getUser().getUserId(),
+					review.getReviewId(),
+					review.getUser().getNickName(),
+					review.getRating(),
+					imageUrl,
+					maxVisitTimes,
+					review.getVisitedAt(),
+					review.getDescription(),
+					isMine
+				);
+			})
+			.collect(Collectors.toList());
 
-		Slice<StoreReviewResponse> storeReviewResponse  = new SliceImpl<>(storeReviewResponseList, reviews.getPageable(), reviews.hasNext());
+		Slice<StoreReviewResponse> storeReviewResponse = new SliceImpl<>(storeReviewResponseList, reviews.getPageable(),
+			reviews.hasNext());
 		return storeReviewResponse;
 	}
 
@@ -194,7 +194,7 @@ public class StoreService {
 				minLatitude, maxLongitude, minLongitude, type);
 		}
 
-		int viewStoreListCount = calculateViewStoreListRatio(storeListWithCondition.size(), viewLevel.getRatio());
+		int viewStoreListCount = calculateViewStoreListRatio(storeListWithCondition.size(), viewLevel);
 
 		totalList.addAll(toStoreLocationRange(bookMarkStoreList, true));
 		totalList.addAll(toStoreLocationRange(storeListWithCondition.subList(0, viewStoreListCount), false));
@@ -202,8 +202,11 @@ public class StoreService {
 		return toStoreLocationRangeResponse(totalList);
 	}
 
-	private int calculateViewStoreListRatio(int listSize, double ratio) {
-		return (int)Math.round(listSize * ratio);
+	private int calculateViewStoreListRatio(int listSize, ViewLevel viewLevel) {
+		if (viewLevel.getMinCount() >= listSize) {
+			return listSize;
+		}
+		return (int)Math.round(listSize * viewLevel.getRatio());
 	}
 
 	private List<Long> storeToIdList(List<Store> storeList) {

--- a/server-domain/src/main/java/com/depromeet/domains/store/repository/StoreRepository.java
+++ b/server-domain/src/main/java/com/depromeet/domains/store/repository/StoreRepository.java
@@ -22,7 +22,7 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
 		+ " 	  AND s.location.longitude >= :minLongitude "
 		+ " 	  AND (s.category.categoryType = :categoryType or :categoryType is null) "
 		+ " 	  AND s.storeId NOT IN (:storeIdList) "
-		+ "    ORDER BY sm.totalReviewCount DESC ")
+		+ "    ORDER BY sm.totalRevisitedCount DESC ")
 	List<Store> findByLocationRangesWithCategory(
 		@Param("maxLatitude") double maxLatitude,
 		@Param("minLatitude") double minLatitude,
@@ -39,7 +39,7 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
 		+ " 	  AND s.location.longitude <= :maxLongitude "
 		+ " 	  AND s.location.longitude >= :minLongitude "
 		+ " 	  AND (s.category.categoryType = :categoryType or :categoryType is null) "
-		+ "    ORDER BY sm.totalReviewCount DESC ")
+		+ "    ORDER BY sm.totalRevisitedCount DESC ")
 	List<Store> findByLocationRangesWithCategoryNoExcept(
 		@Param("maxLatitude") double maxLatitude,
 		@Param("minLatitude") double minLatitude,

--- a/server-domain/src/main/java/com/depromeet/enums/ViewLevel.java
+++ b/server-domain/src/main/java/com/depromeet/enums/ViewLevel.java
@@ -9,19 +9,20 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ViewLevel {
 
-	ONE(1, 1.0),
-	TWO(2, 1.0),
-	THREE(3, 1.0),
-	FOUR(4, 0.9),
-	FIVE(5, 0.8),
-	SIX(6, 0.7),
-	SEVEN(7, 0.6),
-	EIGHT(8, 0.5),
-	NINE(9, 0.4),
-	ETC(-1, 0.0);
+	ONE(1, 1.0, Integer.MAX_VALUE),
+	TWO(2, 1.0, Integer.MAX_VALUE),
+	THREE(3, 1.0, Integer.MAX_VALUE),
+	FOUR(4, 0.9, 20),
+	FIVE(5, 0.8, 20),
+	SIX(6, 0.7, 20),
+	SEVEN(7, 0.6, 15),
+	EIGHT(8, 0.5, 15),
+	NINE(9, 0.4, 15),
+	ETC(-1, 0.0, Integer.MAX_VALUE);
 
 	private final int level;
 	private final double ratio;
+	private final int minCount;
 
 	public static ViewLevel findByLevel(int level) {
 		return Arrays.stream(ViewLevel.values())


### PR DESCRIPTION
### ✅ PR 타입 & 이슈번호
ex) 기능 추가 (#8)

### 📌 상세 내용
- viewLevel 각각에 식당 하한값 정의

### 🔥 궁금한점



