### PR TITLE
[Fix/#111] 리뷰 삭제시 썸네일 변경 및 북마크 삭제

### DIFF
--- a/server-api/src/main/java/com/depromeet/domains/store/service/StoreService.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/service/StoreService.java
@@ -418,14 +418,18 @@ public class StoreService {
 		user.decreaseMyReviewCount();
 
 		if (storeMeta.getTotalReviewCount() == 0) {
+			log.info("해당 음식점 북마크 삭제");
+			bookmarkRepository.deleteByStore(store);
 			log.info("음식점도 삭제");
 			storeRepository.delete(store);
+		} else {
+			Review firstCreatedReview = reviewRepository.findFirstByStoreOrderByVisitedAtAsc(store);
+			store.setThumbnailUrl(firstCreatedReview.getImageUrl());
 		}
 
 		Integer lastIdx = imageUrl.lastIndexOf("/") + 1;
 		String fileName = imageUrl.substring(lastIdx);
 		s3Service.deleteFile(fileName);
-
 	}
 
 	private void processReviewForDuplicateMostVisitor(StoreMeta storeMeta, boolean hasVisitedThreeOrMore) {

--- a/server-domain/src/main/java/com/depromeet/domains/bookmark/repository/BookmarkRepository.java
+++ b/server-domain/src/main/java/com/depromeet/domains/bookmark/repository/BookmarkRepository.java
@@ -14,4 +14,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 	Slice<Bookmark> findByUser(User user, Pageable pageable);
 
 	Optional<Bookmark> findByUserAndStore(User user, Store store);
+
+    void deleteByStore(Store store);
 }

--- a/server-domain/src/main/java/com/depromeet/domains/review/repository/ReviewRepository.java
+++ b/server-domain/src/main/java/com/depromeet/domains/review/repository/ReviewRepository.java
@@ -58,4 +58,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Query("SELECT MAX(r.visitTimes) FROM Review r WHERE r.store = :store AND r.user = :user")
     int maxVisitTimes(@Param("store") Store store, @Param("user") User user);
+
+	// 가장 먼저 생성된 리뷰 조회
+	@Query("SELECT r FROM Review r WHERE r.store = :store ORDER BY r.createdAt ASC")
+	Review findFirstByStoreOrderByVisitedAtAsc(Store store);
 }


### PR DESCRIPTION
### ✅ PR 타입 & 이슈번호
기능 수정 (#111)

### 📌 상세 내용
- 마지막 리뷰 삭제시 해당 음식점 북마크 전부 삭제
- 리뷰 삭제시마다 썸네일을 업데이트(만약 첫리뷰(썸네일로 걸려있는)가 아니면 변경감지가 안일어남)
### 🔥 궁금한점



