### PR TITLE
Feature/#123 맵, 공유하기 api 연관관계 삭제

### DIFF
--- a/server-api/src/main/java/com/depromeet/domains/store/dto/response/StoreLocationRangeResponse.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/dto/response/StoreLocationRangeResponse.java
@@ -26,11 +26,11 @@ public class StoreLocationRangeResponse {
 		private String address;
 		private Double longitude;
 		private Double latitude;
-		private Long totalFeedCount;
+		private Long totalFeedCnt;
 		private Boolean isBookmarked;
 
 		public static StoreLocationRange of(Long storeId, Long kakaoStoreId, String storeName,
-			String address, Double longitude, Double latitude, Long totalFeedCount
+			String address, Double longitude, Double latitude, Long totalFeedCnt
 			, Boolean isBookmarked) {
 			return StoreLocationRange.builder()
 				.storeId(storeId)
@@ -39,7 +39,7 @@ public class StoreLocationRangeResponse {
 				.address(address)
 				.longitude(longitude)
 				.latitude(latitude)
-				.totalFeedCount(totalFeedCount)
+				.totalFeedCnt(totalFeedCnt)
 				.isBookmarked(isBookmarked)
 				.build();
 		}

--- a/server-api/src/main/java/com/depromeet/domains/store/dto/response/StoreSharingSpotResponse.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/dto/response/StoreSharingSpotResponse.java
@@ -28,10 +28,10 @@ public class StoreSharingSpotResponse {
 		private String address;
 		private Double longitude;
 		private Double latitude;
-		private Long totalReviewCount;
+		private Long totalFeedCnt;
 
 		public static StoreSharingSpot of(Long storeId, Long kakaoStoreId, String storeName,
-			String address, Double longitude, Double latitude, Long totalReviewCount) {
+			String address, Double longitude, Double latitude, Long totalFeedCnt) {
 			return StoreSharingSpot.builder()
 				.storeId(storeId)
 				.kakaoStoreId(kakaoStoreId)
@@ -39,7 +39,7 @@ public class StoreSharingSpotResponse {
 				.address(address)
 				.longitude(longitude)
 				.latitude(latitude)
-				.totalReviewCount(totalReviewCount)
+				.totalFeedCnt(totalFeedCnt)
 				.build();
 		}
 	}

--- a/server-api/src/main/java/com/depromeet/domains/store/service/StoreService.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/service/StoreService.java
@@ -179,14 +179,10 @@ public class StoreService {
 					store.getStoreId(),
 					store.getKakaoStoreId(),
 					store.getStoreName(),
-					store.getCategory().getCategoryId(),
-					store.getCategory().getCategoryName(),
-					store.getCategory().getCategoryType().getName(),
 					store.getAddress(),
 					store.getLocation().getLongitude(),
 					store.getLocation().getLatitude(),
-					store.getStoreMeta().getTotalRevisitedCount(),
-					store.getStoreMeta().getTotalReviewCount()))
+					store.getTotalFeedCnt()))
 			.collect(Collectors.toList());
 	}
 

--- a/server-api/src/test/java/com/depromeet/controller/StoreControllerTest.java
+++ b/server-api/src/test/java/com/depromeet/controller/StoreControllerTest.java
@@ -376,7 +376,7 @@ class StoreControllerTest extends RestDocsTestSupport {
 			.address("서울특별시 1")
 			.longitude(127.239487)
 			.latitude(37.29472)
-			.totalFeedCount(1L)
+			.totalFeedCnt(1L)
 			.isBookmarked(true)
 			.build();
 
@@ -387,7 +387,7 @@ class StoreControllerTest extends RestDocsTestSupport {
 			.address("서울특별시 2")
 			.longitude(127.239487)
 			.latitude(37.29472)
-			.totalFeedCount(1L)
+			.totalFeedCnt(1L)
 			.isBookmarked(true)
 			.build();
 
@@ -398,7 +398,7 @@ class StoreControllerTest extends RestDocsTestSupport {
 			.address("서울특별시 3")
 			.longitude(127.239487)
 			.latitude(37.29472)
-			.totalFeedCount(1L)
+			.totalFeedCnt(1L)
 			.isBookmarked(false)
 			.build();
 
@@ -409,7 +409,7 @@ class StoreControllerTest extends RestDocsTestSupport {
 			.address("서울특별시 4")
 			.longitude(127.239487)
 			.latitude(37.29472)
-			.totalFeedCount(1L)
+			.totalFeedCnt(1L)
 			.isBookmarked(false)
 			.build();
 

--- a/server-api/src/test/java/com/depromeet/controller/StoreControllerTest.java
+++ b/server-api/src/test/java/com/depromeet/controller/StoreControllerTest.java
@@ -496,7 +496,7 @@ class StoreControllerTest extends RestDocsTestSupport {
 				.address("서울특별시 1")
 				.longitude(127.239487)
 				.latitude(37.29472)
-				.totalReviewCount(1L)
+				.totalFeedCnt(1L)
 				.build();
 
 		StoreSharingSpotResponse.StoreSharingSpot storeSharingSpot2 =
@@ -507,7 +507,7 @@ class StoreControllerTest extends RestDocsTestSupport {
 				.address("서울특별시 2")
 				.longitude(127.239487)
 				.latitude(37.29472)
-				.totalReviewCount(1L)
+				.totalFeedCnt(1L)
 				.build();
 
 		StoreSharingSpotResponse.StoreSharingSpot storeSharingSpot3 =
@@ -518,7 +518,7 @@ class StoreControllerTest extends RestDocsTestSupport {
 				.address("서울특별시 3")
 				.longitude(127.239487)
 				.latitude(37.29472)
-				.totalReviewCount(1L)
+				.totalFeedCnt(1L)
 				.build();
 
 		StoreSharingSpotResponse.StoreSharingSpot storeSharingSpot4 =
@@ -529,7 +529,7 @@ class StoreControllerTest extends RestDocsTestSupport {
 				.address("서울특별시 4")
 				.longitude(127.239487)
 				.latitude(37.29472)
-				.totalReviewCount(1L)
+				.totalFeedCnt(1L)
 				.build();
 
 		List<StoreSharingSpotResponse.StoreSharingSpot> storeSharingSpotList = Arrays.asList(
@@ -574,8 +574,8 @@ class StoreControllerTest extends RestDocsTestSupport {
 							.description("음식점 위도"),
 						fieldWithPath("data.locationStoreList[].latitude").type(JsonFieldType.NUMBER)
 							.description("음식점 경도"),
-						fieldWithPath("data.locationStoreList[].totalReviewCount").type(JsonFieldType.NUMBER)
-							.description("총 리뷰 갯수")
+						fieldWithPath("data.locationStoreList[].totalFeedCnt").type(JsonFieldType.NUMBER)
+							.description("총 피드 갯수")
 					)
 				)
 			);


### PR DESCRIPTION
### ✅ PR 타입 & 이슈번호
ex) 기능 추가 (#8)

### 📌 상세 내용
- 맵, 공유하기 api 에서 연관관계 끊음(store.getCateogory 쪽)

### 🔥 궁금한점



