### PR TITLE
[Feature/#134] 피드 타입별 조회, 피드 상세 조회

### DIFF
--- a/server-api/src/docs/asciidoc/index.adoc
+++ b/server-api/src/docs/asciidoc/index.adoc
@@ -130,6 +130,17 @@ operation::store-search-controller-test/search[]
 === presigned url 발급
 operation::image-controller-test/get-presigned-url[snippets='curl-request,http-request,http-response,query-parameters,request-headers,response-fields']
 
+== Feed API
+
+=== 1. 피드 전체 조회
+operation::feed-controller-test/get-feeds[]
+
+=== 2. 피드 상세 조회
+operation::feed-controller-test/get-feed[]
+
+=== 5. 피드 삭제
+operation::feed-controller-test/delete-store-feed[]
+
 == Test API
 
 [[test-token]]

--- a/server-api/src/main/java/com/depromeet/common/CursorPagingCommon.java
+++ b/server-api/src/main/java/com/depromeet/common/CursorPagingCommon.java
@@ -1,0 +1,27 @@
+package com.depromeet.common;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
+
+public class CursorPagingCommon {
+
+    public static <T> Slice<T> getSlice(List<?> responses, Integer size) {
+
+        boolean hasNext = false;
+        if (responses.size() > size) {
+            // 마지막 항목 제거하여 다음 페이지 존재 여부 확인
+            responses.remove(responses.size() - 1);
+            hasNext = true;
+        }
+
+        // Pageable 객체 생성
+        Pageable pageable = PageRequest.of(0, size);
+
+        // SliceImpl 객체로 반환
+        return (Slice<T>)  new SliceImpl<>(responses, pageable, hasNext);
+    }
+}

--- a/server-api/src/main/java/com/depromeet/domains/feed/controller/FeedController.java
+++ b/server-api/src/main/java/com/depromeet/domains/feed/controller/FeedController.java
@@ -24,7 +24,7 @@ public class FeedController {
     @GetMapping
     public CustomResponseEntity<Slice<FeedResponse>> getFeeds(@AuthUser User user,
                                                               @RequestParam(value = "type") String type,
-                                                              @RequestParam(value = "lastIdxId") Long lastIdxId,
+                                                              @RequestParam(value = "lastIdxId", required = false) Long lastIdxId,
                                                               @RequestParam(value = "size") Integer size) {
         return CustomResponseEntity.success(feedService.getFeeds(lastIdxId, user, type, size));
     }

--- a/server-api/src/main/java/com/depromeet/domains/feed/controller/FeedController.java
+++ b/server-api/src/main/java/com/depromeet/domains/feed/controller/FeedController.java
@@ -55,7 +55,7 @@ public class FeedController {
     }
 
     // 피드 댓글 조회
-    @
+
 
     // 피드 댓글 수정
 

--- a/server-api/src/main/java/com/depromeet/domains/feed/controller/FeedController.java
+++ b/server-api/src/main/java/com/depromeet/domains/feed/controller/FeedController.java
@@ -2,10 +2,13 @@ package com.depromeet.domains.feed.controller;
 
 import com.depromeet.annotation.AuthUser;
 import com.depromeet.common.exception.CustomResponseEntity;
+import com.depromeet.domains.feed.dto.response.FeedDetailResponse;
+import com.depromeet.domains.feed.dto.response.FeedResponse;
 import com.depromeet.domains.feed.service.FeedService;
 import com.depromeet.domains.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Slice;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -17,9 +20,20 @@ public class FeedController {
     private final FeedService feedService;
 
     // 피드 전체 조회
+    @GetMapping
+    public CustomResponseEntity<Slice<FeedResponse>> getFeeds(@AuthUser User user,
+                                                              @RequestParam(value = "type") String type,
+                                                              @RequestParam(value = "lastIdxId") Long lastIdxId,
+                                                              @RequestParam(value = "size") Integer size) {
+        return CustomResponseEntity.success(feedService.getFeeds(lastIdxId, user, type, size));
+    }
 
     // 피드 상세 조회
-
+    @GetMapping("/{feedId}")
+    public CustomResponseEntity<FeedDetailResponse> getFeed(@AuthUser User user,
+                                                            @PathVariable Long feedId) {
+        return CustomResponseEntity.success(feedService.getFeed(user, feedId));
+    }
     // 피드 작성
 
     // 피드 수정

--- a/server-api/src/main/java/com/depromeet/domains/feed/controller/FeedController.java
+++ b/server-api/src/main/java/com/depromeet/domains/feed/controller/FeedController.java
@@ -2,6 +2,7 @@ package com.depromeet.domains.feed.controller;
 
 import com.depromeet.annotation.AuthUser;
 import com.depromeet.common.exception.CustomResponseEntity;
+import com.depromeet.domains.feed.dto.request.FeedUpdateRequest;
 import com.depromeet.domains.feed.dto.response.FeedDetailResponse;
 import com.depromeet.domains.feed.dto.response.FeedResponse;
 import com.depromeet.domains.feed.service.FeedService;
@@ -37,6 +38,13 @@ public class FeedController {
     // 피드 작성
 
     // 피드 수정
+    @PutMapping("/{feedId}")
+    public CustomResponseEntity<Void> updateFeed(@AuthUser User user,
+                                                        @PathVariable Long feedId,
+                                                        @RequestBody FeedUpdateRequest feedUpdateRequest) {
+        feedService.updateFeed(user, feedId, feedUpdateRequest);
+        return CustomResponseEntity.success();
+    }
 
     // 피드 삭제
     @DeleteMapping("/{feedId}")
@@ -45,4 +53,11 @@ public class FeedController {
         feedService.deleteFeed(user, feedId);
         return CustomResponseEntity.success();
     }
+
+    // 피드 댓글 조회
+    @
+
+    // 피드 댓글 수정
+
+    // 피드 댓글 삭제
 }

--- a/server-api/src/main/java/com/depromeet/domains/feed/controller/FeedController.java
+++ b/server-api/src/main/java/com/depromeet/domains/feed/controller/FeedController.java
@@ -40,7 +40,7 @@ public class FeedController {
 
     // 피드 삭제
     @DeleteMapping("/{feedId}")
-    public CustomResponseEntity<Void> deleteStoreReview(@AuthUser User user,
+    public CustomResponseEntity<Void> deleteFeed(@AuthUser User user,
                                                         @PathVariable Long feedId) {
         feedService.deleteFeed(user, feedId);
         return CustomResponseEntity.success();

--- a/server-api/src/main/java/com/depromeet/domains/feed/service/FeedService.java
+++ b/server-api/src/main/java/com/depromeet/domains/feed/service/FeedService.java
@@ -13,10 +13,7 @@ import com.depromeet.domains.user.entity.User;
 import com.depromeet.domains.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/server-api/src/main/java/com/depromeet/domains/feed/service/FeedService.java
+++ b/server-api/src/main/java/com/depromeet/domains/feed/service/FeedService.java
@@ -36,7 +36,7 @@ public class FeedService {
     @Transactional(readOnly = true)
     public Slice<FeedResponse> getFeeds(Long lastIdxId, User user, String type, Integer size) {
         User findUser = findUserById(user.getUserId());
-        List<FeedResponse> feedResponses = feedRepository.findByUserIdAndType(lastIdxId, findUser.getUserId(), type, size);
+        List<FeedResponse> feedResponses = feedRepository.findFeedAll(lastIdxId, findUser.getUserId(), type, size);
         Slice<FeedResponse> responses= getSlice(feedResponses, size);
         return responses;
     }

--- a/server-api/src/main/java/com/depromeet/domains/feed/service/FeedService.java
+++ b/server-api/src/main/java/com/depromeet/domains/feed/service/FeedService.java
@@ -2,6 +2,7 @@ package com.depromeet.domains.feed.service;
 
 import com.depromeet.common.exception.CustomException;
 import com.depromeet.common.exception.Result;
+import com.depromeet.domains.feed.dto.request.FeedUpdateRequest;
 import com.depromeet.domains.feed.dto.response.FeedDetailResponse;
 import com.depromeet.domains.feed.dto.response.FeedResponse;
 import com.depromeet.domains.feed.entity.Feed;
@@ -35,8 +36,7 @@ public class FeedService {
     // 피드 전체 조회
     @Transactional(readOnly = true)
     public Slice<FeedResponse> getFeeds(Long lastIdxId, User user, String type, Integer size) {
-        User findUser = findUserById(user.getUserId());
-        List<FeedResponse> feedResponses = feedRepository.findFeedAll(lastIdxId, findUser.getUserId(), type, size);
+        List<FeedResponse> feedResponses = feedRepository.findFeedAll(lastIdxId, user.getUserId(), type, size);
         Slice<FeedResponse> responses= getSlice(feedResponses, size);
         return responses;
     }
@@ -44,14 +44,22 @@ public class FeedService {
     // 피드 상세 조회
     @Transactional(readOnly = true)
     public FeedDetailResponse getFeed(User user, Long feedId) {
-        User findUser = findUserById(user.getUserId());
-        FeedDetailResponse feedDetail = feedRepository.findFeedDetail(findUser.getUserId(), feedId);
+        FeedDetailResponse feedDetail = feedRepository.findFeedDetail(user.getUserId(), feedId);
         return feedDetail;
     }
 
     // 피드 작성
 
     // 피드 수정
+    @Transactional
+    public void updateFeed(User user, Long feedId, FeedUpdateRequest feedUpdateRequest) {
+        Feed feed = feedRepository.findById(feedId).orElseThrow(() -> new CustomException(Result.NOT_FOUND_FEED));
+        if (!feed.getUserId().equals(user.getUserId())) {
+            throw new CustomException(Result.UNAUTHORIZED_USER);
+        }
+
+        feed.updateFeed(feedUpdateRequest.getRating(), feedUpdateRequest.getImageUrl(), feedUpdateRequest.getDescription());
+    }
 
     // 피드 삭제
     @Transactional

--- a/server-api/src/main/java/com/depromeet/domains/feed/service/FeedService.java
+++ b/server-api/src/main/java/com/depromeet/domains/feed/service/FeedService.java
@@ -2,15 +2,26 @@ package com.depromeet.domains.feed.service;
 
 import com.depromeet.common.exception.CustomException;
 import com.depromeet.common.exception.Result;
+import com.depromeet.domains.feed.dto.response.FeedDetailResponse;
+import com.depromeet.domains.feed.dto.response.FeedResponse;
 import com.depromeet.domains.feed.entity.Feed;
 import com.depromeet.domains.feed.repository.FeedRepository;
 import com.depromeet.domains.store.entity.Store;
 import com.depromeet.domains.store.repository.StoreRepository;
 import com.depromeet.domains.user.entity.User;
+import com.depromeet.domains.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.depromeet.common.CursorPagingCommon.getSlice;
 
 @Service
 @RequiredArgsConstructor
@@ -19,10 +30,24 @@ public class FeedService {
 
     private final FeedRepository feedRepository;
     private final StoreRepository storeRepository;
+    private final UserRepository userRepository;
 
     // 피드 전체 조회
+    @Transactional(readOnly = true)
+    public Slice<FeedResponse> getFeeds(Long lastIdxId, User user, String type, Integer size) {
+        User findUser = findUserById(user.getUserId());
+        List<FeedResponse> feedResponses = feedRepository.findByUserIdAndType(lastIdxId, findUser.getUserId(), type, size);
+        Slice<FeedResponse> responses= getSlice(feedResponses, size);
+        return responses;
+    }
 
     // 피드 상세 조회
+    @Transactional(readOnly = true)
+    public FeedDetailResponse getFeed(User user, Long feedId) {
+        User findUser = findUserById(user.getUserId());
+        FeedDetailResponse feedDetail = feedRepository.findFeedDetail(findUser.getUserId(), feedId);
+        return feedDetail;
+    }
 
     // 피드 작성
 
@@ -41,5 +66,9 @@ public class FeedService {
         user.decreaseMyFeedCount();
 
         feedRepository.delete(feed);
+    }
+
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId).orElseThrow(() -> new CustomException(Result.NOT_FOUND_USER));
     }
 }

--- a/server-api/src/main/java/com/depromeet/domains/store/controller/StoreController.java
+++ b/server-api/src/main/java/com/depromeet/domains/store/controller/StoreController.java
@@ -67,11 +67,12 @@ public class StoreController {
 		return CustomResponseEntity.success(storeService.getStoreReport(storeId));
 	}
 
-	@GetMapping("/stores/{storeId}/reviews")
+	@GetMapping("/stores/{storeId}/feeds")
 	public CustomResponseEntity<Slice<StoreFeedResponse>> getStoreFeed(@AuthUser User user,
 																	   @PathVariable Long storeId,
-																	   Pageable pageable) {
-		return CustomResponseEntity.success(storeService.getStoreFeed(user, storeId, pageable));
+																	   @RequestParam(value = "lastIdxId") Long lastIdxId,
+																	   @RequestParam(value = "size") Integer size) {
+		return CustomResponseEntity.success(storeService.getStoreFeed(user, storeId, lastIdxId, size));
 	}
 
 	@PostMapping("/stores/feeds")

--- a/server-api/src/test/java/com/depromeet/controller/FeedControllerTest.java
+++ b/server-api/src/test/java/com/depromeet/controller/FeedControllerTest.java
@@ -1,0 +1,202 @@
+package com.depromeet.controller;
+
+import com.depromeet.document.RestDocsTestSupport;
+import com.depromeet.domains.feed.dto.response.FeedDetailResponse;
+import com.depromeet.domains.feed.dto.response.FeedResponse;
+import com.depromeet.domains.store.dto.StoreFeedResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@WithMockUser
+public class FeedControllerTest extends RestDocsTestSupport {
+
+    @Test
+    void getFeeds() throws Exception {
+        FeedResponse feedResponse1 = FeedResponse.builder()
+                .userId(1L)
+                .profileImg("profileImg")
+                .nickname("kim")
+                .storeId(1L)
+                .storeName("버거킹")
+                .kakaoCategoryName("패스트푸드")
+                .address("서울시 강남구")
+                .feedId(1L)
+                .description("맛있어요")
+                .feedImg("feedImg")
+                .createdAt(LocalDateTime.now())
+                .isFollowed(true)
+                .build();
+
+        FeedResponse feedResponse2 = FeedResponse.builder()
+                .userId(2L)
+                .profileImg("profileImg")
+                .nickname("필환")
+                .storeId(2L)
+                .storeName("롯데리아")
+                .kakaoCategoryName("패스트푸드")
+                .address("서울시 강남구")
+                .feedId(2L)
+                .description("맛있어요11")
+                .feedImg("feedImg")
+                .createdAt(LocalDateTime.now())
+                .isFollowed(false)
+                .build();
+
+        List<FeedResponse> content = Arrays.asList(feedResponse1, feedResponse2);
+        Pageable pageable = PageRequest.of(0, 10);
+        Slice<FeedResponse> feedResponses = new SliceImpl<>(content, pageable, true);
+
+        given(feedService.getFeeds(anyLong(), any(), anyString(), anyInt())).willReturn(feedResponses);
+
+        mockMvc.perform(
+                        get("/api/v1/feeds")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header("Authorization", "Bearer accessToken")
+                                .param("type", "ALL")
+                                .param("lastIdxId", "13")
+                                .param("size", "10"))
+                .andExpect(status().isOk())
+                .andDo(
+                        restDocs.document(
+                                queryParameters(
+                                        parameterWithName("type").description("피드 조회 타입"),
+                                        parameterWithName("lastIdxId").description("마지막 원소 ID"),
+                                        parameterWithName("size").description("페이지 크기")
+                                ),
+                                requestHeaders(
+                                        headerWithName("Authorization").description("accessToken")
+                                ),
+                                responseFields(
+                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과코드"),
+                                        fieldWithPath("message").type(JsonFieldType.STRING).description("결과메시지"),
+                                        subsectionWithPath("data.content[]").type(JsonFieldType.ARRAY).description("리뷰 목록"),
+                                        fieldWithPath("data.content[].userId").type(JsonFieldType.NUMBER).description("사용자 ID"),
+                                        fieldWithPath("data.content[].profileImg").type(JsonFieldType.STRING).description("프로필 이미지 URL"),
+                                        fieldWithPath("data.content[].nickname").type(JsonFieldType.STRING).description("닉네임"),
+                                        fieldWithPath("data.content[].storeId").type(JsonFieldType.NUMBER).description("가게 ID"),
+                                        fieldWithPath("data.content[].storeName").type(JsonFieldType.STRING).description("가게 이름"),
+                                        fieldWithPath("data.content[].kakaoCategoryName").type(JsonFieldType.STRING).description("카카오 카테고리 이름"),
+                                        fieldWithPath("data.content[].address").type(JsonFieldType.STRING).description("주소"),
+                                        fieldWithPath("data.content[].feedId").type(JsonFieldType.NUMBER).description("피드 ID"),
+                                        fieldWithPath("data.content[].description").type(JsonFieldType.STRING).description("리뷰 내용"),
+                                        fieldWithPath("data.content[].feedImg").type(JsonFieldType.STRING).description("이미지 URL"),
+                                        fieldWithPath("data.content[].createdAt").type(JsonFieldType.STRING).description("생성일"),
+                                        fieldWithPath("data.content[].isFollowed").type(JsonFieldType.BOOLEAN).description("자신의 리뷰인지 여부"),
+                                        subsectionWithPath("data.pageable").type(JsonFieldType.OBJECT).description("페이지 정보"),
+                                        fieldWithPath("data.pageable.pageNumber").type(JsonFieldType.NUMBER).description("페이지 번호"),
+                                        fieldWithPath("data.pageable.pageSize").type(JsonFieldType.NUMBER).description("페이지 크기"),
+                                        subsectionWithPath("data.pageable.sort").type(JsonFieldType.OBJECT).description("정렬 정보"),
+                                        fieldWithPath("data.pageable.sort.empty").type(JsonFieldType.BOOLEAN).description("정렬 정보가 비어 있는지 여부"),
+                                        fieldWithPath("data.pageable.sort.sorted").type(JsonFieldType.BOOLEAN).description("정렬이 되어 있는지 여부"),
+                                        fieldWithPath("data.pageable.sort.unsorted").type(JsonFieldType.BOOLEAN).description("정렬이 되어 있지 않은지 여부"),
+                                        fieldWithPath("data.pageable.offset").type(JsonFieldType.NUMBER).description("페이지 오프셋"),
+                                        fieldWithPath("data.pageable.paged").type(JsonFieldType.BOOLEAN).description("페이지가 페이징 되어 있는지 여부"),
+                                        fieldWithPath("data.pageable.unpaged").type(JsonFieldType.BOOLEAN).description("페이지가 페이징 되어 있지 않은지 여부"),
+                                        fieldWithPath("data.first").type(JsonFieldType.BOOLEAN).description("첫 번째 페이지 여부"),
+                                        fieldWithPath("data.last").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
+                                        fieldWithPath("data.size").type(JsonFieldType.NUMBER).description("페이지 크기"),
+                                        fieldWithPath("data.number").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
+                                        subsectionWithPath("data.sort").type(JsonFieldType.OBJECT).description("정렬 정보"),
+                                        fieldWithPath("data.numberOfElements").type(JsonFieldType.NUMBER).description("현재 페이지의 요소 수"),
+                                        fieldWithPath("data.empty").type(JsonFieldType.BOOLEAN).description("현재 페이지가 비어 있는지 여부")
+                                )
+                        )
+                );
+
+    }
+
+    @Test
+    void getFeed() throws Exception {
+        FeedDetailResponse feedDetailResponse = FeedDetailResponse.builder()
+                .userId(1L)
+                .profileImg("image.url")
+                .nickname("kim")
+                .storeId(1L)
+                .storeName("버거킹")
+                .kakaoCategoryName("패스트푸드")
+                .address("서울시 강남")
+                .feedId(1L)
+                .description("맛남요")
+                .feedImg("image.url")
+                .createdAt(LocalDateTime.now())
+                .isFollowed(false)
+                .rating(1).build();
+
+        given(feedService.getFeed(any(), anyLong())).willReturn(feedDetailResponse);
+
+        mockMvc.perform(
+                        get("/api/v1/feeds/{feedId}", 1L)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header("Authorization", "Bearer accessToken"))
+                .andExpect(status().isOk())
+                .andDo(
+                        restDocs.document(
+                                pathParameters(
+                                        parameterWithName("feedId").description("피드 ID")
+                                ),
+                                requestHeaders(
+                                        headerWithName("Authorization").description("accessToken")
+                                ),
+                                responseFields(
+                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과코드"),
+                                        fieldWithPath("message").type(JsonFieldType.STRING).description("결과메시지"),
+                                        fieldWithPath("data.userId").type(JsonFieldType.NUMBER).description("사용자 ID"),
+                                        fieldWithPath("data.profileImg").type(JsonFieldType.STRING).description("프로필 이미지 URL"),
+                                        fieldWithPath("data.nickname").type(JsonFieldType.STRING).description("닉네임"),
+                                        fieldWithPath("data.storeId").type(JsonFieldType.NUMBER).description("가게 ID"),
+                                        fieldWithPath("data.storeName").type(JsonFieldType.STRING).description("가게 이름"),
+                                        fieldWithPath("data.kakaoCategoryName").type(JsonFieldType.STRING).description("카카오 카테고리 이름"),
+                                        fieldWithPath("data.address").type(JsonFieldType.STRING).description("주소"),
+                                        fieldWithPath("data.feedId").type(JsonFieldType.NUMBER).description("피드 ID"),
+                                        fieldWithPath("data.description").type(JsonFieldType.STRING).description("리뷰 내용"),
+                                        fieldWithPath("data.feedImg").type(JsonFieldType.STRING).description("피드 이미지 URL"),
+                                        fieldWithPath("data.createdAt").type(JsonFieldType.STRING).description("피드 생성일자"),
+                                        fieldWithPath("data.isFollowed").type(JsonFieldType.BOOLEAN).description("팔로우 여부"),
+                                        fieldWithPath("data.rating").type(JsonFieldType.NUMBER).description("평점")
+                                )
+                        )
+                );
+    }
+
+    @Test
+    void deleteStoreReview() throws Exception {
+        doNothing().when(feedService).deleteFeed(any(), anyLong());
+
+        mockMvc.perform(delete("/api/v1/feeds/{feedId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer accessToken"))
+                .andExpect(status().isOk())
+                .andDo(
+                        restDocs.document(
+                                pathParameters(
+                                        parameterWithName("feedId").description("피드 ID")
+                                )));
+    }
+}

--- a/server-api/src/test/java/com/depromeet/controller/FeedControllerTest.java
+++ b/server-api/src/test/java/com/depromeet/controller/FeedControllerTest.java
@@ -186,7 +186,7 @@ public class FeedControllerTest extends RestDocsTestSupport {
     }
 
     @Test
-    void deleteStoreReview() throws Exception {
+    void deleteStoreFeed() throws Exception {
         doNothing().when(feedService).deleteFeed(any(), anyLong());
 
         mockMvc.perform(delete("/api/v1/feeds/{feedId}", 1L)

--- a/server-domain/src/main/java/com/depromeet/domains/feed/dto/request/FeedUpdateRequest.java
+++ b/server-domain/src/main/java/com/depromeet/domains/feed/dto/request/FeedUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.depromeet.domains.feed.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedUpdateRequest {
+    private Integer rating;
+    private String imageUrl;
+    private String description;
+}

--- a/server-domain/src/main/java/com/depromeet/domains/feed/dto/response/FeedDetailResponse.java
+++ b/server-domain/src/main/java/com/depromeet/domains/feed/dto/response/FeedDetailResponse.java
@@ -15,6 +15,7 @@ public class FeedDetailResponse {
     private String storeName;
     private String kakaoCategoryName;
     private String address;
+    private Long feedId;
     private String description;
     private String feedImg;
     private LocalDateTime createdAt; // 피드의 생성일자

--- a/server-domain/src/main/java/com/depromeet/domains/feed/dto/response/FeedDetailResponse.java
+++ b/server-domain/src/main/java/com/depromeet/domains/feed/dto/response/FeedDetailResponse.java
@@ -1,0 +1,28 @@
+package com.depromeet.domains.feed.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class FeedDetailResponse {
+    private Long userId;
+    private String profileImg;
+    private String nickname;
+    private Long storeId;
+    private String storeName;
+    private String kakaoCategoryName;
+    private String address;
+    private String description;
+    private String feedImg;
+    private LocalDateTime createdAt; // 피드의 생성일자
+    private Boolean isFollowed; // 팔로우 여부
+    private Integer rating; // 별점
+
+    /*
+    private Integer commentCnt; // 댓글 수
+    private Integer likeCnt; // 좋아요 수
+    */
+}

--- a/server-domain/src/main/java/com/depromeet/domains/feed/dto/response/FeedDetailResponse.java
+++ b/server-domain/src/main/java/com/depromeet/domains/feed/dto/response/FeedDetailResponse.java
@@ -1,5 +1,6 @@
 package com.depromeet.domains.feed.dto.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,6 +8,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@AllArgsConstructor
 public class FeedDetailResponse {
     private Long userId;
     private String profileImg;

--- a/server-domain/src/main/java/com/depromeet/domains/feed/dto/response/FeedResponse.java
+++ b/server-domain/src/main/java/com/depromeet/domains/feed/dto/response/FeedResponse.java
@@ -1,0 +1,23 @@
+package com.depromeet.domains.feed.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class FeedResponse {
+
+    private Long userId;
+    private String profileImg;
+    private String nickname;
+    private Long storeId;
+    private String storeName;
+    private String kakaoCategoryName;
+    private String address;
+    private String description;
+    private String feedImg;
+    private LocalDateTime createdAt; // 피드의 생성일자
+    private Boolean isFollowed; // 팔로우 여부
+}

--- a/server-domain/src/main/java/com/depromeet/domains/feed/dto/response/FeedResponse.java
+++ b/server-domain/src/main/java/com/depromeet/domains/feed/dto/response/FeedResponse.java
@@ -16,6 +16,7 @@ public class FeedResponse {
     private String storeName;
     private String kakaoCategoryName;
     private String address;
+    private Long feedId;
     private String description;
     private String feedImg;
     private LocalDateTime createdAt; // 피드의 생성일자

--- a/server-domain/src/main/java/com/depromeet/domains/feed/dto/response/FeedResponse.java
+++ b/server-domain/src/main/java/com/depromeet/domains/feed/dto/response/FeedResponse.java
@@ -1,5 +1,6 @@
 package com.depromeet.domains.feed.dto.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,6 +8,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@AllArgsConstructor
 public class FeedResponse {
 
     private Long userId;

--- a/server-domain/src/main/java/com/depromeet/domains/feed/entity/Feed.java
+++ b/server-domain/src/main/java/com/depromeet/domains/feed/entity/Feed.java
@@ -2,6 +2,7 @@ package com.depromeet.domains.feed.entity;
 
 import com.depromeet.domains.common.entity.BaseTimeEntity;
 
+import com.depromeet.domains.feed.dto.request.FeedUpdateRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -50,4 +51,9 @@ public class Feed extends BaseTimeEntity {
 	@Column(nullable = false)
 	private Long commentCnt;
 
+	public void updateFeed(Integer rating, String imageUrl, String description) {
+		this.rating = rating;
+		this.imageUrl = imageUrl;
+		this.description = description;
+	}
 }

--- a/server-domain/src/main/java/com/depromeet/domains/feed/entity/FeedType.java
+++ b/server-domain/src/main/java/com/depromeet/domains/feed/entity/FeedType.java
@@ -1,0 +1,20 @@
+package com.depromeet.domains.feed.entity;
+
+import com.depromeet.enums.EnumType;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum FeedType implements EnumType{
+    ALL("모든 피드"), FOLLOW("팔로우 피드");
+    private final String description;
+
+    @Override
+    public String getName() {
+        return this.name();
+    }
+
+    @Override
+    public String getDescription() {
+        return this.description;
+    }
+}

--- a/server-domain/src/main/java/com/depromeet/domains/feed/repository/FeedRepositoryCustom.java
+++ b/server-domain/src/main/java/com/depromeet/domains/feed/repository/FeedRepositoryCustom.java
@@ -2,6 +2,8 @@ package com.depromeet.domains.feed.repository;
 
 
 
+import com.depromeet.domains.feed.dto.response.FeedDetailResponse;
+import com.depromeet.domains.feed.dto.response.FeedResponse;
 import com.depromeet.domains.store.dto.StoreFeedResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -17,8 +19,13 @@ public interface FeedRepositoryCustom {
 	Long countStoreReviewByUserForDay(Long userId, Long storeId, LocalDateTime startOfDay, LocalDateTime endOfDay);
 
     List<String> findTop10FeedImagesByCreatedAtDesc(Long storeId);
-    Slice<StoreFeedResponse> findFeedByStoreId(Long storeId, Pageable pageable, Long userId);
+    List<StoreFeedResponse> findFeedByStoreId(Long storeId, Long userId, Long lastFeedId, Integer size);
 	boolean existsByStoreAndUser(Long storeId, Long userId);
 
 	Slice<Feed> findByUserId(Long userId, Pageable pageable);
+
+	// type 별 피드 조회(ALL, FOLLOW)
+	List<FeedResponse> findByUserIdAndType(Long lastFeedId, Long userId, String type, Integer size);
+
+	FeedDetailResponse findFeedDetail(Long userId, Long feedId);
 }

--- a/server-domain/src/main/java/com/depromeet/domains/feed/repository/FeedRepositoryCustom.java
+++ b/server-domain/src/main/java/com/depromeet/domains/feed/repository/FeedRepositoryCustom.java
@@ -25,7 +25,7 @@ public interface FeedRepositoryCustom {
 	Slice<Feed> findByUserId(Long userId, Pageable pageable);
 
 	// type 별 피드 조회(ALL, FOLLOW)
-	List<FeedResponse> findByUserIdAndType(Long lastFeedId, Long userId, String type, Integer size);
+	List<FeedResponse> findFeedAll(Long lastFeedId, Long userId, String type, Integer size);
 
 	FeedDetailResponse findFeedDetail(Long userId, Long feedId);
 }

--- a/server-domain/src/main/java/com/depromeet/domains/feed/repository/FeedRepositoryImpl.java
+++ b/server-domain/src/main/java/com/depromeet/domains/feed/repository/FeedRepositoryImpl.java
@@ -112,7 +112,7 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
     }
 
     @Override
-    public List<FeedResponse> findByUserIdAndType(Long lastFeedId, Long userId, String type, Integer size) {
+    public List<FeedResponse> findFeedAll(Long lastFeedId, Long userId, String type, Integer size) {
         BooleanExpression condition = getTypeCondition(userId, type);
 
 
@@ -125,6 +125,7 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                         store.storeName,
                         store.kakaoCategoryName,
                         store.address,
+                        feed.feedId,
                         feed.description,
                         feed.imageUrl,
                         feed.createdAt,
@@ -164,6 +165,7 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                         store.storeName,
                         store.kakaoCategoryName,
                         store.address,
+                        feed.feedId,
                         feed.description,
                         feed.imageUrl,
                         feed.createdAt,

--- a/server-domain/src/main/java/com/depromeet/domains/feed/repository/FeedRepositoryImpl.java
+++ b/server-domain/src/main/java/com/depromeet/domains/feed/repository/FeedRepositoryImpl.java
@@ -2,7 +2,12 @@ package com.depromeet.domains.feed.repository;
 
 import java.util.List;
 
+import com.depromeet.domains.feed.dto.response.FeedDetailResponse;
+import com.depromeet.domains.feed.dto.response.FeedResponse;
+import com.depromeet.domains.follow.entity.QFollow;
 import com.depromeet.domains.store.dto.StoreFeedResponse;
+import com.depromeet.domains.store.entity.QStore;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -19,12 +24,16 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 
+import static com.querydsl.jpa.JPAExpressions.select;
+
 @Repository
 @RequiredArgsConstructor
 public class FeedRepositoryImpl implements FeedRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
     QFeed feed = QFeed.feed;
-
+    QUser user = QUser.user;
+    QFollow follow = QFollow.follow;
+    QStore store = QStore.store;
 
     @Override
     public Long countStoreReviewByUserForDay(Long userId, Long storeId, LocalDateTime startOfDay,
@@ -50,10 +59,7 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
     }
 
     @Override
-    public Slice<StoreFeedResponse> findFeedByStoreId(Long storeId, Pageable pageable, Long userId) {
-        QFeed feed = QFeed.feed;
-        QUser user = QUser.user;
-
+    public List<StoreFeedResponse> findFeedByStoreId(Long storeId, Long userId, Long lastFeedId, Integer size) {
         List<StoreFeedResponse> results = jpaQueryFactory
                 .select(Projections.fields(StoreFeedResponse.class,
                         feed.userId,
@@ -67,37 +73,14 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                         feed.userId.eq(userId)))
                 .from(feed)
                 .join(user).on(feed.userId.eq(user.userId))
-                .where(ltFeedId((long) pageable.getPageNumber()),
+                .where(ltFeedId(lastFeedId),
                         feed.storeId.eq(storeId))
                 .orderBy(feed.createdAt.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize() + 1)
+                .orderBy(feed.createdAt.desc())
+                .limit(size+1)
                 .fetch();
 
-        return checkLastPage(pageable, results);
-    }
-
-    // no-offset 방식 처리하는 메서드
-    private BooleanExpression ltFeedId(Long feedId) {
-        if (feedId == null) {
-            return null;
-        }
-
-        return feed.feedId.lt(feedId);
-    }
-
-    // 무한 스크롤 방식 처리하는 메서드
-    private Slice<StoreFeedResponse> checkLastPage(Pageable pageable, List<StoreFeedResponse> results) {
-
-        boolean hasNext = false;
-
-        // 조회한 결과 개수가 요청한 페이지 사이즈보다 크면 뒤에 더 있음, next = true
-        if (results.size() > pageable.getPageSize()) {
-            hasNext = true;
-            results.remove(pageable.getPageSize());
-        }
-
-        return new SliceImpl<>(results, pageable, hasNext);
+        return results;
     }
 
     @Override
@@ -126,5 +109,90 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
         List<Feed> content = hasNext ? results.subList(0, pageable.getPageSize()) : results;
 
         return new SliceImpl<>(content, pageable, hasNext);
+    }
+
+    @Override
+    public List<FeedResponse> findByUserIdAndType(Long lastFeedId, Long userId, String type, Integer size) {
+        BooleanExpression condition = getTypeCondition(userId, type);
+
+
+        List<FeedResponse> results = jpaQueryFactory
+                .select(Projections.constructor(FeedResponse.class,
+                        user.userId,
+                        user.profileImageUrl,
+                        user.nickName,
+                        store.storeId,
+                        store.storeName,
+                        store.kakaoCategoryName,
+                        store.address,
+                        feed.description,
+                        feed.imageUrl,
+                        feed.createdAt,
+                        select(follow.receiverId.count().gt(0))
+                                .from(follow)
+                                .where(follow.senderId.eq(userId)
+                                        .and(follow.receiverId.eq(feed.userId)))
+                                .exists().as("isFollowed")))
+                .from(feed)
+                .join(store).on(feed.storeId.eq(store.storeId))
+                .join(user).on(feed.userId.eq(user.userId))
+                .join(follow).on(feed.userId.eq(follow.receiverId))
+                .where(condition,
+                        ltFeedId(lastFeedId))
+                .orderBy(feed.createdAt.desc())
+                .limit(size+1)
+                .fetch();
+
+        return results;
+    }
+
+    @Override
+    public FeedDetailResponse findFeedDetail(Long userId, Long feedId) {
+
+        BooleanExpression isFollowedSubQuery = select(follow.receiverId.count().gt(0))
+                .from(follow)
+                .where(follow.senderId.eq(userId)
+                        .and(follow.receiverId.eq(feed.userId)))
+                .exists();
+
+        FeedDetailResponse result = jpaQueryFactory
+                .select(Projections.constructor(FeedDetailResponse.class,
+                        user.userId,
+                        user.profileImageUrl,
+                        user.nickName,
+                        store.storeId,
+                        store.storeName,
+                        store.kakaoCategoryName,
+                        store.address,
+                        feed.description,
+                        feed.imageUrl,
+                        feed.createdAt,
+                        isFollowedSubQuery, // 서브쿼리 결과를 생성자 인자로 전달
+                        feed.rating))
+                .from(feed)
+                .join(store).on(feed.storeId.eq(store.storeId))
+                .join(user).on(feed.userId.eq(user.userId))
+                .where(feed.feedId.eq(feedId))
+                .fetchOne();
+        return result;
+    }
+
+    // type에 따른 조건 생성을 담당하는 private 메서드
+    private BooleanExpression getTypeCondition(Long userId, String type) {
+        return type.equals("FOLLOW") ? feed.userId.in(
+                jpaQueryFactory
+                        .select(follow.receiverId)
+                        .from(follow)
+                        .where(follow.senderId.eq(userId))
+        ) : null; // "ALL"일 경우 null을 전달하여 모든 피드를 조회
+    }
+
+    // no-offset 방식 처리하는 메서드
+    private BooleanExpression ltFeedId(Long feedId) {
+        if (feedId == null) {
+            return null;
+        }
+
+        return feed.feedId.lt(feedId);
     }
 }


### PR DESCRIPTION
### ✅ PR 타입 & 이슈번호
기능 추가 (#134)

### 📌 상세 내용
- 피드 상세 조회, 피드 타입별 조회(ALL, FOLLOW) 생성
- cursor 기반으로 조회하기 위해 List 타입의 조회결과를 Slice로 매핑하는 CursorPagingCommon 생성
### 🔥 궁금한점



